### PR TITLE
[ BUG ] Title Changes from `REACTAPP` to `LinkFree`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>LinkFree</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Have updated the title of React App

Fixes #97 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/99"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

