### PR TITLE
fix: footer add white space after github logo(#137)

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -15,7 +15,7 @@ function Footer() {
         <a href="https://github.com/EddieHubCommunity/LinkFree">
           <i className="pi pi-github" aria-hidden="true"></i>
         </a>
-        v{version}
+        &nbsp;v{version}
       </p>
     </div>
   )


### PR DESCRIPTION
<!-- issue number -->
Fixes #

## Proposed Changes

  - Add white space after GitHub logo on the footer


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

