### PR TITLE
fix open links in deferent tabs

### DIFF
--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -10,10 +10,6 @@ function Links({ links }) {
     github: '#171515',
   }
 
-  const goToLinkHandle = (url) => {
-    window.open(url, '__blank').focus()
-  }
-
   return (
     <div className="p-d-flex p-jc-center">
       <div className="p-d-flex p-flex-column" style={{ width: 70 + '%' }}>
@@ -24,7 +20,7 @@ function Links({ links }) {
               className="p-p-3 p-m-2 p-button-outlined"
               style={{ color: colors[link.icon] }}
               key={`link.url_${index}`}
-              onClick={() => goToLinkHandle(link.url)}
+              onClick={() => window.open(link.url)}
             >
               <i className={`pi pi-${link.icon} p-px-2`}></i>
               <span className="p-px-3">{link.name}</span>


### PR DESCRIPTION
Fix open links in different tabs
## Proposed Changes

  - remove goToLinkHandle function
  - add window.open to Link onChange directly
 
## Screenshots
### before:
![link_open_1](https://user-images.githubusercontent.com/6501582/133152937-593d97be-e6da-44dc-8064-5ccea6c02eb7.gif)


### after:
![link_open_2](https://user-images.githubusercontent.com/6501582/133153100-d157d091-5082-4051-9312-b0a866781952.gif)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/153"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

