### PR TITLE
feat: increase `scale` on hovering links

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.p-button{
+  transition: transform 0.33s!important;
+}
+
+.p-button:hover{
+  transform: scale(1.02);
+}


### PR DESCRIPTION
<!-- issue number -->
Fixes #135

## Proposed Changes
- Make the links larger on hover, looks cool & interactive as well 💥 
- Demo after merging this PR:
![linkfree-hover-new](https://user-images.githubusercontent.com/70312106/133202059-f87fdbb9-fa92-454a-9192-76078ecf19fc.gif)

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/160"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

