### PR TITLE
Change position of profile badge

### DIFF
--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -14,7 +14,7 @@ function Profile({ name, bio, avatar, total }) {
           shape="circle"
           className="p-overlay-badge"
         >
-          <Badge value={total} severity="info" />
+          <Badge value={total} severity="info" className="p-mr-2 p-mt-2"/>
         </Avatar>
         <h1 className="p-m-2">{name}</h1>
       </div>


### PR DESCRIPTION
Fixes #139

## Proposed Changes

  - Position the profile badge as the red notification badges you get on mobile.

## Screenshots

<img width="568" alt="image" src="https://user-images.githubusercontent.com/9541039/133286379-3f5c27a5-317c-40a4-b791-6ff944c414b1.png">


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

