### PR TITLE
fix: Use HTTPS instead of HTTP in `data/ShreeyansJain.json`

### DIFF
--- a/public/data/ShreyaansJain.json
+++ b/public/data/ShreyaansJain.json
@@ -5,12 +5,12 @@
   "links": [
     {
       "name": "Follow me on GitHub",
-      "url": "http://github.com/shreyaansjain06",
+      "url": "https://github.com/shreyaansjain06",
       "icon": "github"
     },
     {
       "name": "Follow me on Twitter",
-      "url": "http://twitter.com/shreyaansjain06",
+      "url": "https://twitter.com/shreyaansjain06",
       "icon": "twitter"
     }
   ]


### PR DESCRIPTION
## Proposed Changes

- Use HTTPS instead of HTTP in `data/ShreeyansJain.json`.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/279"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

