### PR TITLE
Added Discord

### DIFF
--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -12,7 +12,7 @@ function Links({ links }) {
     github: '#171515',
     instagram: '#E4405F',
     linkedin: '#0077b5',
-    discord: '5865F2',
+    discord: '#5865F2',
   }
 
   const goToLinkHandle = (url) => {

--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -12,6 +12,7 @@ function Links({ links }) {
     github: '#171515',
     instagram: '#E4405F',
     linkedin: '#0077b5',
+    discord: '5865F2',
   }
 
   const goToLinkHandle = (url) => {


### PR DESCRIPTION
Fixes #328 , added hex #5865F2 for discord, but is the discord icon present in `primeicons` ? @eddiejaoude @Panquesito7 @kkhitesh 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

