### PR TITLE
feat: Add icon for website related links (#401)

### DIFF
--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -10,6 +10,7 @@ function Links({ links }) {
     youtube: '#FF0000',
     twitter: '#1DA1F2',
     github: '#171515',
+    globe: '#A9A9A9',
     instagram: '#E4405F',
     linkedin: '#0077b5',
   }


### PR DESCRIPTION
Added an icon from prime react to cater for website links

Fixes #401 

#### Actual:
![Actual result](https://user-images.githubusercontent.com/50571688/135663847-c7d32cbf-0371-4f1c-915c-e3e8cbb15c22.jpg)



#### Expected:
![globe icon eddiehub](https://user-images.githubusercontent.com/50571688/135663964-49a9ff4e-e840-417e-9fcc-09b75f0084b1.jpg)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/403"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

