### PR TITLE
feat: Avatar replaced with Chip (#364)

### DIFF
--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -1,7 +1,16 @@
-.p-avatar {
-  transition: transform 0.33s !important;
+a{
+  text-decoration: none;
 }
-
-.p-avatar:hover {
-  transform: scale(1.2);
+.p-chip{
+  padding: 0.2rem 0.6rem;
+}
+.p-chip:hover{
+  transform: scale(1.1);
+}
+.p-chip-text{
+  color: black;
+}
+.p-chip img{
+  height: 2.5rem;
+  width: 2.5rem;
 }

--- a/src/Components/Home/Placeholders.js
+++ b/src/Components/Home/Placeholders.js
@@ -9,8 +9,8 @@ function Placeholder({ list }) {
       {list.map((user, key) => {
         return (
           <Skeleton
-            shape="circle"
-            size="65px"
+            width="15%"
+            height="2.4rem" borderRadius="10px"
             className="p-mr-2 p-m-2"
             key={`skeleton-${key}`}
           />

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -1,18 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Avatar } from 'primereact/avatar'
+import { Chip } from 'primereact/chip'
 
 function User({ list }) {
   return (
     <>
       {list.map((user, key) => (
         <a href={`${user.username}`} key={`avatar-${key}`}>
-          <Avatar
+          <Chip
             image={user.avatar}
-            shape="circle"
-            size="xlarge"
             className="p-m-2"
-            imageAlt={user.username}
+            label={user.username}
           />
         </a>
       ))}


### PR DESCRIPTION
fixes #364

This PR replaces the `Avatar` component with `Chip` as it makes it more user-friendly. It also changes the shape of the skeleton to a rectangle as it relates more to a Chip shape 

You can have a look at the screen recording for reference

https://user-images.githubusercontent.com/48324492/135666748-a3de930a-060d-414d-bed2-479092992576.mov


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

