### PR TITLE
fix: linkedin, catch all links (#377)

### DIFF
--- a/public/data/eddiejaoude.json
+++ b/public/data/eddiejaoude.json
@@ -21,7 +21,7 @@
     {
       "name": "Follow me on LinkedIn",
       "url": "http://linkedin.com/in/eddiejaoude",
-      "icon": "linked"
+      "icon": "linkedin"
     }
   ],
   "milestones": [

--- a/src/Components/Links.css
+++ b/src/Components/Links.css
@@ -6,18 +6,26 @@
   transform: scale(1.02);
 }
 
+.p-button.p-button-outlined:not(a):not(.p-disabled).unknown:hover {
+  background-color: #333;
+}
+
 .p-button.p-button-outlined:not(a):not(.p-disabled).twitter:hover {
   background-color: #1da1f2;
 }
+
 .p-button.p-button-outlined:not(a):not(.p-disabled).youtube:hover {
   background-color: #ff0000;
 }
+
 .p-button.p-button-outlined:not(a):not(.p-disabled).github:hover {
   background-color: #211f1f;
 }
+
 .p-button.p-button-outlined:not(a):not(.p-disabled).linkedin:hover {
   background-color: #0077b5;
 }
+
 .p-button.p-button-outlined:not(a):not(.p-disabled).instagram:hover {
   background-color: #e4405f;
 }

--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -13,7 +13,7 @@ function Links({ links }) {
     facebook: '#1877F2',
     github: '#171515',
     instagram: '#E4405F',
-    linkedin: '#0077b5',
+    // linkedin: '#0077b5', // does not exist in icon set yet
     microsoft: '#5E5E5E',
     paypal: '#00457C',
     slack: '#4A154B',
@@ -28,7 +28,10 @@ function Links({ links }) {
 
   return (
     <section className="p-d-flex p-jc-center p-mb-4">
-      <div className="p-d-flex p-flex-column" style={{ width: 70 + '%', maxWidth: 45 + 'rem' }}>
+      <div
+        className="p-d-flex p-flex-column"
+        style={{ width: 70 + '%', maxWidth: 45 + 'rem' }}
+      >
         {links
           .filter((link) => Object.keys(colors).includes(link.icon))
           .map((link, index) => (
@@ -40,6 +43,19 @@ function Links({ links }) {
               role="link"
             >
               <i className={`pi pi-${link.icon} p-px-2`}></i>
+              <span className="p-px-3">{link.name}</span>
+            </Button>
+          ))}
+        {links
+          .filter((link) => !Object.keys(colors).includes(link.icon))
+          .map((link, index) => (
+            <Button
+              className="p-p-3 p-m-2 p-button-outlined unknown"
+              key={`link.url_${index}`}
+              onClick={() => goToLinkHandle(link.url)}
+              role="link"
+            >
+              <i className="pi pi-arrow-right p-px-2"></i>
               <span className="p-px-3">{link.name}</span>
             </Button>
           ))}


### PR DESCRIPTION
Fixed #377 

- [x] linkedin icon does not exist
- [x] links with no icons fall back to the arrow icon and grey colours


<img width="1055" alt="Screenshot 2021-10-02 at 06 23 59" src="https://user-images.githubusercontent.com/624760/135705095-96575cc2-aff7-4ad3-9816-b1189f1278e4.png">


<img width="1154" alt="Screenshot 2021-10-02 at 06 24 04" src="https://user-images.githubusercontent.com/624760/135705098-a2c0d3f2-9710-479b-877f-aadc95202c02.png">




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/415"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

