### PR TITLE
Add alphabetical sorting to homepage list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkfree",
-  "version": "0.27.3",
+  "version": "0.27.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linkfree",
-      "version": "0.27.3",
+      "version": "0.27.6",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,8 +1,9 @@
 import './Home.css'
 
-import React, { useState, useEffect } from 'react'
-import { ProgressBar } from 'primereact/progressbar'
+import React, { useEffect, useState } from 'react'
+
 import { Avatar } from 'primereact/avatar'
+import { ProgressBar } from 'primereact/progressbar'
 
 function Home() {
   const [showProgress, setShowProgress] = useState(true)
@@ -11,6 +12,7 @@ function Home() {
   useEffect(() => {
     fetch('/list.json')
       .then((response) => response.json())
+      .then((data) => data.sort((a, b) => a.username.localeCompare(b.username)))
       .then((data) => setList(data))
       .catch((error) => {
         console.log('Home useEffect', error)


### PR DESCRIPTION
## Fixes Issue

Closes #95 

Adding a sort method in the callback of `fetch('/list.json')`

## Changes proposed

## Check List (Check all the boxes which are applicable)

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![image](https://user-images.githubusercontent.com/11391766/135723580-2ae57057-eef6-4fbd-92d4-ee59f2302a2f.png)


## Note to reviewers

<!-- Add a note to reviewers if applicable -->