### PR TITLE
feat: Add width to the user chips(#479)

### DIFF
--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -6,6 +6,7 @@ a {
   transition: transform 0.33s;
   padding: 0.4rem 0.9rem;
   border-radius: 2rem;
+  width: 16rem;
 }
 
 .p-chip:hover {


### PR DESCRIPTION
Resolve #479 

This PR aligns the users on the homepage in a consistent manner.  Apply the styling to the Chip component and set the width of each user.

Visual Changes:
![image](https://user-images.githubusercontent.com/65766473/136868343-52ec8645-7d96-4742-8a4d-debee92a239e.png)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/500"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

