### PR TITLE
Fix: resize alternative text overflow in avatar images.

### DIFF
--- a/src/Components/Profile.css
+++ b/src/Components/Profile.css
@@ -5,6 +5,6 @@
   line-height: 30px;
 }
 
-.p-avatar-image > img{
+.p-avatar-image > img {
   font-size: 0.5em;
 }


### PR DESCRIPTION
Resolve #481:

Changes:
- Resized alternative text of avatars to `0.5 em`.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/505"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

