### PR TITLE
Fix broken contributing links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, skip all the steps by using [![Gitpod Ready-to-Code](https://img.
 
 - Contributions are what makes the open source community such an amazing place to learn, inspire, and create. 
 - Any contributions you make are **greatly appreciated**.
-- Check out our [contribution guidelines](https://github.com/EddieHubCommunity/LinkFree/blob/main/CONTRIBUTING.md) for more information.
+- Check out our [contribution guidelines](https://github.com/EddieHubCommunity/LinkFree/blob/main/Contributing.md) for more information.
 
 ## 🎭 To Add Your Profile
 


### PR DESCRIPTION
Fix #541

The broken contributing links in the readme file has been fixed to point to the right link.

Here is a screenshot confirming that it opens at the intended location.

![Screenshot from 2021-10-20 17-46-33](https://user-images.githubusercontent.com/42704349/138136085-58ab65f8-c477-4e0d-9d64-413b28d684ad.png)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/542"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

