### PR TITLE
Make social link buttons rounded

### DIFF
--- a/src/Components/Links.css
+++ b/src/Components/Links.css
@@ -33,7 +33,7 @@
 }
 
 .p-button.p-button-outlined:not(a):not(.p-disabled).envelope:hover {
-  background-color: #5f6368;
+  background-color: #5F6368;
 }
 
 .p-button-outlined:hover > i {


### PR DESCRIPTION
resolve #432

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/548"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

increasing border width is making it ugly