### PR TITLE
Fix: discord and paypal hover issue fix

### DIFF
--- a/src/Components/Links.css
+++ b/src/Components/Links.css
@@ -35,6 +35,14 @@
   background-color: #5F6368;
 }
 
+.p-button.p-button-outlined:not(a):not(.p-disabled).paypal:hover {
+  background-color: #00457C;
+}
+
+.p-button.p-button-outlined:not(a):not(.p-disabled).discord:hover {
+  background-color: #5865F2;
+}
+
 .p-button-outlined:hover > i {
   color: #fff;
 }


### PR DESCRIPTION
This fixes https://github.com/EddieHubCommunity/LinkFree/issues/560

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/568"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

