### PR TITLE
fix: Inconsistent gaps on homepage

### DIFF
--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -14,3 +14,9 @@ a {
   box-shadow: rgba(255, 255, 255, 0.2) 0px 0px 0px 1px inset,
     rgba(0, 0, 0, 0.9) 0px 0px 0px 1px;
 }
+
+span.p-chip-text{
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Closes #609 
I used CSS code to truncate the text to fit the div. As a result, all the gaps are of the same size now - 
### Before -
![image](https://user-images.githubusercontent.com/70312106/138858700-e440e06b-d8b7-46c5-bb1f-1fe8d300f9a7.png)
### After -
![image](https://user-images.githubusercontent.com/70312106/138858349-f75929f2-fced-4601-9cf0-3064bfe02756.png)
The code doesn't effect the search functionality in any way

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/610"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

