### PR TITLE
fix: more consistent loading skeleton

### DIFF
--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -1,14 +1,12 @@
 import './Home.css'
 
 import React, { useState, useEffect, useRef } from 'react'
-import { ProgressBar } from 'primereact/progressbar'
 import { Toast } from 'primereact/toast'
 
 import Placeholders from './Placeholders'
 import Users from './Users'
 
 function Home() {
-  const [showProgress, setShowProgress] = useState(true)
   const [list, setList] = useState([])
   const [skeleton, setskeleton] = useState(true)
   const toast = useRef(null)
@@ -28,7 +26,6 @@ function Home() {
         })
       })
       .finally(() => {
-        setShowProgress(false)
         setTimeout(() => {
           setskeleton(false)
         }, 500)
@@ -38,7 +35,6 @@ function Home() {
   return (
     <main>
       <Toast ref={toast} />
-      {showProgress && <ProgressBar mode="indeterminate" />}
       {skeleton ? <Placeholders list={list} /> : <Users list={list} />}
     </main>
   )

--- a/src/Components/Home/Placeholders.js
+++ b/src/Components/Home/Placeholders.js
@@ -5,19 +5,26 @@ import { Skeleton } from 'primereact/skeleton'
 
 function Placeholder({ list }) {
   return (
+    <>
+    <Skeleton
+      shape="rectangle"
+      height="3.2rem"
+      className="p-mb-4"
+    />
     <div className="p-d-flex p-flex-wrap">
       {list.map((user, key) => {
         return (
           <Skeleton
-            width="15%"
-            height="2.4rem"
-            borderRadius="10px"
-            className="p-mr-2 p-m-2"
+            width="16rem"
+            height="2.6rem"
+            borderRadius="2rem"
+            className="p-m-2 p-mr-2"
             key={`skeleton-${key}`}
           />
         )
       })}
     </div>
+    </>
   )
 }
 

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -16,7 +16,7 @@ function Users({ list }) {
           <Searchbar searchTerm={searchTerm} searchHandler={searchHandler} />
         }
       />
-      <div className="user-list">
+      <div>
         {list
           .filter((User) =>
             User.name.toLowerCase().includes(searchTerm.toLowerCase()),


### PR DESCRIPTION
resolves #601 

## Description

This PR intends to reduce the differences between the loading skeleton and the Users page.
The `ProgressBar` on the main page has been removed since it overlapped with the skeleton for the `MenuBar`
(*though, I think maybe we can set the `ProgressBar` to appear before the Skeleton for the links gets rendered, in a later PR).

## Preview

https://user-images.githubusercontent.com/62864373/139380276-ac63d133-9a18-43a7-843c-45f36ab9bf03.mov




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/619"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

