### PR TITLE
Fix: Profile picture is not loading

### DIFF
--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 
 import { Avatar } from 'primereact/avatar'
 import { Badge } from 'primereact/badge'
-import ImageLoader from './ImageLoader'
 
 function Profile({ profile, username }) {
   const { name, bio, avatar, links } = profile
@@ -18,7 +17,6 @@ function Profile({ profile, username }) {
           imageAlt={`Profile picture of ${name}`}
           size="xlarge"
           shape="circle"
-          template={<ImageLoader avatar={avatar} username={name} />}
           className="p-overlay-badge"
         >
           <Badge


### PR DESCRIPTION
Fixes https://github.com/EddieHubCommunity/LinkFree/issues/629. The issue was with Image Loader. We don't need the image loader template here. We will already have the image url when this component loads. 

Post fix screenshot
![image](https://user-images.githubusercontent.com/26025710/139781506-c328353b-2a90-4f4d-bbc1-392b9ee55077.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

