### PR TITLE
Fix: Cards shrinking in mobile breakpoint

### DIFF
--- a/src/Components/Milestones.js
+++ b/src/Components/Milestones.js
@@ -25,7 +25,7 @@ function Milestones({ milestones }) {
     <Card
       title={milestone.title}
       subTitle={milestone.date}
-      className="p-m-5 p-shadow-15"
+      className="p-my-5 p-mx-md-5 p-shadow-15"
     >
       {milestone.image && (
         <img
@@ -57,7 +57,7 @@ function Milestones({ milestones }) {
 
   return (
     <section className="p-d-flex p-jc-center p-mb-5">
-      <div style={{ width: 70 + '%' }}>
+      <div className="p-md-8">
         <Timeline
           value={milestones}
           align="alternate"


### PR DESCRIPTION
This fixes https://github.com/EddieHubCommunity/LinkFree/issues/630. Post fix screenshot

![image](https://user-images.githubusercontent.com/26025710/139792705-17f13c3b-7119-4ce5-a2ab-2fdcb71a82cc.png)


NOTE: I have changed the width in PC screen from 70% to 66.6 % cause that was the closest width provided in prime react. I don't think this is breaking anything though. Just a minor change in UI.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/633"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

