### PR TITLE
feat: change sort from username to name

### DIFF
--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -14,7 +14,7 @@ function Home() {
   useEffect(() => {
     fetch('/list.json')
       .then((response) => response.json())
-      .then((data) => data.sort((a, b) => a.username.localeCompare(b.username)))
+      .then((data) => data.sort((a, b) => a.name.localeCompare(b.name)))
       .then((data) => setList(data))
       .catch((error) => {
         console.log('Home useEffect', error)


### PR DESCRIPTION
closes #638

### Description

sort people on homepage by name not by username

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/30869493/140022357-e21a1181-fcc6-4cbc-8111-36a1c8c3af37.png)
After:
![image](https://user-images.githubusercontent.com/30869493/140022393-bedecf5d-f6e8-4009-abba-108e00464b9a.png)


### Additional information

Sorting folks by name due the display-name is the normal name not the username.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

