### PR TITLE
fixed spelling mistake in error page

### DIFF
--- a/src/Components/UserProfile/ErrorPage.js
+++ b/src/Components/UserProfile/ErrorPage.js
@@ -7,7 +7,7 @@ function ErrorPage() {
         <img src='/eddiehub_community_logo.webp' alt="image" style={{ width: '150px' }}/>
         <h1>Profile not found.</h1>
         <h1>If you are a new user, please consider registering at LinkFree.</h1>
-        <h2>Read the documendation <a href="https://github.com/EddieHubCommunity/LinkFree#readme" target="_blank" rel="noreferrer">here</a>.</h2>
+        <h2>Read the documentation <a href="https://github.com/EddieHubCommunity/LinkFree#readme" target="_blank" rel="noreferrer">here</a>.</h2>
       </div>
     </div>
   )


### PR DESCRIPTION
fixed the spelling of documentation which was "documendation" earlier.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/666"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

