### PR TITLE
fix: card text consistent alignment on mobile

### DIFF
--- a/src/Components/Milestone.css
+++ b/src/Components/Milestone.css
@@ -18,4 +18,9 @@
   .p-timeline-event {
     display: inline;
   }
+  .p-card-title,
+  .p-card-subtitle,
+  .p-card-content {
+    text-align: center;
+  }
 }

--- a/src/Components/Milestone.css
+++ b/src/Components/Milestone.css
@@ -18,6 +18,7 @@
   .p-timeline-event {
     display: inline;
   }
+
   .p-card-title,
   .p-card-subtitle,
   .p-card-content {


### PR DESCRIPTION
Closes #665
Made card text center for mobile view (max width 960px)
Current Alignment:
![image](https://user-images.githubusercontent.com/35369843/141769251-bb06ad04-a54b-45c4-8f31-07379b484568.png)

After Change:
![image](https://user-images.githubusercontent.com/35369843/141769338-44b7b4c6-12e8-475d-ae3b-ca4a7b328c4e.png)

No Change in Desktop View: 
![image](https://user-images.githubusercontent.com/35369843/141769447-5ed10d44-df5f-4608-bd1f-e9733a9ec752.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/668"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

