### PR TITLE
docs - Fix the href links and changed the fork icon

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -11,7 +11,7 @@
 
 ## ⭐ HOW TO MAKE A PULL REQUEST:
 
-**1.** Start by making a fork the [**LinkFree**](https://github.com/EddieHubCommunity/LinkFree) repository. Click on the <a href="https://github.com/EddieHubCommunity/LinkFree/fork"><img src="https://seekicon.com/free-icon-download/git-fork_1.svg" height="18" width="18"></a> symbol at the top right corner.
+**1.** Start by making a fork the [**LinkFree**](https://github.com/EddieHubCommunity/LinkFree) repository. Click on the <a href="https://github.com/EddieHubCommunity/LinkFree/fork"><img src="https://i.imgur.com/G4z1kEe.png" height="21" width="21"></a> symbol at the top right corner.
 
 **2.** Clone your new fork of the repository:
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -4,14 +4,14 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.png?v=103)](https://github.com/ellerbrock/open-source-badges/)
 
 - Take a look at the existing [Issues](https://github.com/EddieHubCommunity/LinkFree/issues) or [create a new issue](https://github.com/EddieHubCommunity/LinkFree/issues/new/choose)!
-- [Fork the Repo](https://github.com/EddieHubCommunity/LinkFree/network/members), create a branch for any issue that you are working on and commit your work.
+- [Fork the Repo](https://github.com/EddieHubCommunity/LinkFree/fork), create a branch for any issue that you are working on and commit your work.
 - Create a **[Pull Request](https://github.com/EddieHubCommunity/LinkFree/compare)** (*PR*), which will be promptly reviewed and given suggestions for improvements by the community.
 - Add screenshots or screen captures to your Pull Request to help us understand the effects of the changes that are included in your commits.
 
 
 ## ⭐ HOW TO MAKE A PULL REQUEST:
 
-**1.** Start by making a fork the [**LinkFree**](https://github.com/EddieHubCommunity/LinkFree) repository. Click on the <a href="https://github.com/EddieHubCommunity/LinkFree/network/members"><img src="https://img.icons8.com/ios/24/32CD32/code-fork.png"></a> symbol at the top right corner.
+**1.** Start by making a fork the [**LinkFree**](https://github.com/EddieHubCommunity/LinkFree) repository. Click on the <a href="https://github.com/EddieHubCommunity/LinkFree/fork"><img src="https://seekicon.com/free-icon-download/git-fork_1.svg" height="18" width="18"></a> symbol at the top right corner.
 
 **2.** Clone your new fork of the repository:
 


### PR DESCRIPTION
The fork icon which was used is similar to the branch icon, so I have changed it into the current version of branch icon 
Few href links (the ones related to fork where redirecting to `https://github.com/EddieHubCommunity/LinkFree/network/members` instead of `https://github.com/EddieHubCommunity/LinkFree/fork`) weren't redirecting to the proper page as expected 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/680"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

