### PR TITLE
docs: Removed Trailing '/'.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
 - name: 🙋🏾🙋🏼‍Question
-  url: http://discord.eddiehub.org/
+  url: http://discord.eddiehub.org
   about: Feel free to ask your question on our Discord channel.


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Hello @eddiejaoude @krishguptadev ,

I have removed the trailing '/' for the issue resolve #717 


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/718"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

