### PR TITLE
fix: usage of static img url

### DIFF
--- a/public/data/KaushikK.json
+++ b/public/data/KaushikK.json
@@ -1,7 +1,7 @@
 {
   "name": "Kaushik",
   "bio": "Student",
-  "avatar": "https://avatars.githubusercontent.com/KaushikKC",
+  "avatar": "https://github.com/KaushikK.png",
   "links": [
     {
       "name": "Follow me on GitHub",


### PR DESCRIPTION
fixes #734 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/735"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

