### PR TITLE
fix: usage of wrong img url

### DIFF
--- a/public/data/givenkiban1.json
+++ b/public/data/givenkiban1.json
@@ -1,7 +1,7 @@
 {
   "name": "Given Kibanza",
   "bio": "Entreprenuer // Dev // Robotics X Space X Medicine",
-  "avatar": "https://pbs.twimg.com/profile_images/1034593703187435520/ZxopmcXJ_400x400.jpg",
+  "avatar": "https://github.com/givenkiban1.png",
   "links": [
     {
       "name": "Follow me on GitHub",


### PR DESCRIPTION
Cc @givenkiban1 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

fixes #736 