### PR TITLE
docs: Add gitpod tutorial gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree)
 
-![LinkFree](https://user-images.githubusercontent.com/51878265/144558359-81be1ac3-7059-435c-a0a1-0278b6b61880.gif)
+![Gitpod GIF](https://user-images.githubusercontent.com/51878265/144558359-81be1ac3-7059-435c-a0a1-0278b6b61880.gif)
 
 ## 👨‍💻 Demo
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 
 ![LinkFree](https://user-images.githubusercontent.com/51878265/144558359-81be1ac3-7059-435c-a0a1-0278b6b61880.gif)
 
-
 ## 👨‍💻 Demo
 
 Check out the website: [LinkFree](http://linkfree.eddiehub.org/)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree)
 
+![LinkFree](https://user-images.githubusercontent.com/51878265/144558359-81be1ac3-7059-435c-a0a1-0278b6b61880.gif)
+
+
 ## 👨‍💻 Demo
 
 Check out the website: [LinkFree](http://linkfree.eddiehub.org/)


### PR DESCRIPTION
### Description

Added a short tutorial (_In GIF format_) on how to open **Remote Explorer** on GitPod.

### Fixes 
resolve #761

### Screenshots
![Screenshot from 2021-12-03 12-32-00](https://user-images.githubusercontent.com/51878265/144559620-5889282e-3997-4052-8b72-96dbbdab28b3.png)

#### **This is Idea is driven by @eddiejaoude** 👏👏
<p align="center"><img src = "https://user-images.githubusercontent.com/51878265/144560140-e23983fd-d227-4f27-bc07-3c51096edd2e.png" height=300></p>

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

