### PR TITLE
chore: Add a new milestone `eddiejaoude.json`

### DIFF
--- a/public/data/eddiejaoude.json
+++ b/public/data/eddiejaoude.json
@@ -57,6 +57,14 @@
       "color": "green",
       "description": "Won GitHub Star of the Year out of 55+ million people",
       "url": "https://github.com/eddiejaoude"
+    },
+    {
+      "title": "GitHub Nova, Community Growth Award",
+      "date": "2021",
+      "icon": "github",
+      "color": "green",
+      "description": "Won for growing the EddieHub Community to over 30k members.",
+      "url": "https://github.com/eddiejaoude"
     }
   ]
 }


### PR DESCRIPTION
### Description

Added a new milestone (**GitHub Nova, Community Growth Award, 2021**) in `eddiejaoude.json`
 
### Fixes 
Resolve #762 

### Screenshots

![Screenshot from 2021-12-03 14-56-56](https://user-images.githubusercontent.com/51878265/144578760-5ff2ef61-0002-4852-81b6-78e2614813a4.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/764"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

