### PR TITLE
docs: update directory path link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > A note for Hacktoberfest Participants:
 >
-> Pull requests which add or edit your information in a `data/${yourname}.json` file will NOT be counted for Hacktoberfest.
+> Pull requests which add or edit your information in a `public/data/${yourname}.json` file will NOT be counted for Hacktoberfest.
 >
 > Pull requests which improve the codebase, documentation, or other aspects of the project and are in line with the core values
 > of the event will count - maintainers will opt-in these PRs by applying the `hacktoberfest-accepted` label.


### PR DESCRIPTION
### Changes proposed

Update the dir path link

Current one:
`data/${yourname}.json`

After Correction:
`public/data/${yourname}.json`




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/781"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

