### PR TITLE
feat: add customizable profile background theme

### DIFF
--- a/public/data/Tejas-Teju.json
+++ b/public/data/Tejas-Teju.json
@@ -1,6 +1,7 @@
 {
     "name": "Tejas S",
     "type": "personal",
+    "theme": "#ffe680",
     "bio": "A Coding Enthusiast ",
     "avatar": "https://github.com/Tejas-Teju.png",
     "links": [

--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -36,6 +36,7 @@ function Home() {
       })
   }, [])
 
+  document.body.style.background = '#fff'
   return (
     <main>
       <Toast ref={toast} />

--- a/src/Components/UserProfile/ProfilePage.js
+++ b/src/Components/UserProfile/ProfilePage.js
@@ -6,6 +6,7 @@ import Links from '../Links'
 import Milestones from '../Milestones'
 
 function ProfilePage({ profile, username }) {
+  document.body.style.background = profile.theme
   return (
     <>
       {
@@ -23,6 +24,7 @@ ProfilePage.propTypes = {
   username: PropTypes.string.isRequired,
   profile: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    theme: PropTypes.string,
     bio: PropTypes.string.isRequired,
     avatar: PropTypes.string.isRequired,
     links: PropTypes.arrayOf(


### PR DESCRIPTION
## Feature [#616 ](https://github.com/EddieHubCommunity/LinkFree/issues/616)

## Changes proposed
Now, users can view the background theme of user's choice when they visit profile page however, the background theme must be present in <profile_name>.json file else default background is set i.e. #fff (White). 

## Check List (Check all the applicable boxes) 
- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://user-images.githubusercontent.com/34937107/146417472-c976276f-e7df-4d9a-8907-1ccdcba7979a.png)
![image](https://user-images.githubusercontent.com/34937107/146417620-6791e592-4798-4479-a9ee-68b83f24ee9c.png)
![image](https://user-images.githubusercontent.com/34937107/146417930-1347a436-95d5-4409-bda1-fc3ce819241c.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/820"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

