### PR TITLE
Add tabIndex attribute to scroll to top btn

### DIFF
--- a/src/Components/ScrollToTopBtn.js
+++ b/src/Components/ScrollToTopBtn.js
@@ -26,7 +26,6 @@ function ScrollToTopBtn() {
         top: 0,
         behavior: 'smooth',
       })
-      setScrollBtnVisibility(scrollBtnVisibility)
     }
   }
 

--- a/src/Components/ScrollToTopBtn.js
+++ b/src/Components/ScrollToTopBtn.js
@@ -20,16 +20,20 @@ function ScrollToTopBtn() {
     }
   }, [])
 
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
-    setScrollBtnVisibility(scrollBtnVisibility)
+  const scrollToTop = (e) => {
+    if (e.type === 'click' || e.key === 'Enter') {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      })
+      setScrollBtnVisibility(scrollBtnVisibility)
+    }
   }
 
   return (
     <BsFillArrowUpCircleFill
+      tabIndex={0}
+      onKeyPress={scrollToTop}
       style={scrollBtnVisibility ? {} : { display: 'none' }}
       className="scrollToTop-btn"
       onClick={scrollToTop}


### PR DESCRIPTION
Closes #990 

Simply adding tabIndex attribute to the button did not work in the sense that pressing Enter did not trigger the function.

My solution was to add onKeyPress attribute to the button and pass it the same function as for onClick.

This of course meant that I had to make sure that only pressing 'Enter' and clicking on the button trigger that function.
Hence the condition.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/992"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

