### PR TITLE
change <h4> to <p> in Profile.js to meet a11y requirements

### DIFF
--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -23,7 +23,7 @@ function Profile({ profile, username }) {
         />
         <div className="flex flex-column sm:flex-row justify-content-center align-items-center">
           <h1 className="m-2">{name}</h1>
-          <h4 className="my-0">({username})</h4>
+          <p className="my-0 font-bold">({username})</p>
         </div>
       </div>
       <div className="flex justify-content-center w-50">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #1007 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
To fulfill A11Y requirements the `<h4>` tag was changed into an `<p>` tag with the same styling as a `<h4>` tag. Therefore, the UI keeps the same but the A11Y increased in the Lighthouse results.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Increased Lighthouse results
<img width="731" alt="Lighthouse results showing 97% in accessibility" src="https://user-images.githubusercontent.com/54622834/150187176-10e61aae-6c3f-4dd0-b70a-9ae7db03f405.png">

Same UI
<img width="429" alt="Contributors avatar, name and username" src="https://user-images.githubusercontent.com/54622834/150187597-43d02f7d-9a66-4cc5-9726-6b4f88d3b592.png">



