### PR TITLE
change buttons to links #1016

### DIFF
--- a/cypress/integration/user.feature
+++ b/cypress/integration/user.feature
@@ -16,5 +16,5 @@ Feature: User profile page
 
     Scenario: Check links appear on user profile
         Given I open "eddiejaoude" page
-        Then I see "Follow me on GitHub" text in section "button"
-        And I see "Follow me on Twitter" text in section "button"
+        Then I see "Follow me on GitHub" text in section "a"
+        And I see "Follow me on Twitter" text in section "a"

--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -2,7 +2,7 @@ import './Links.css'
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button } from 'primereact/button'
+import StyledLink from './StyledLink'
 import GetIcons from './Icons/GetIcons'
 import { IconContext } from 'react-icons/lib'
 import linksConfig from '../config/links.json'
@@ -24,14 +24,13 @@ function Links({ links }) {
         {links
           .filter((link) => Object.keys(colors).includes(link.icon))
           .map((link, index) => (
-            <Button
+            <StyledLink
               key={`link.url_${index}`}
               onMouseOver={(e) => MouseOver(e, colors[link.icon])}
               onMouseOut={MouseOut}
               className={`p-3 my-2 p-button-outlined ${link.icon}`}
               style={{ color: colors[link.icon] }}
-              role="link"
-              onClick={() => window.open(link.url, '_blank')}
+              href={link.url}
             >
               <IconContext.Provider
                 value={{
@@ -41,19 +40,18 @@ function Links({ links }) {
                 <GetIcons iconName={link.icon} />
               </IconContext.Provider>
               <span className="px-3">{link.name}</span>
-            </Button>
+            </StyledLink>
           ))}
         {links
           .filter((link) => !Object.keys(colors).includes(link.icon))
           .map((link, index) => (
-            <Button
+            <StyledLink
               key={`link.url_${index}`}
               onMouseOver={(e) => MouseOver(e, colors.globe)}
               onMouseOut={MouseOut}
               className={`p-3 my-2 p-button-outlined ${link.icon}`}
               style={{ color: colors.globe }}
-              role="link"
-              onClick={() => window.open(link.url, '_blank')}
+              href={link.url}
             >
               <IconContext.Provider
                 value={{
@@ -63,7 +61,7 @@ function Links({ links }) {
                 <GetIcons iconName={link.icon} />
               </IconContext.Provider>
               <span className="px-3">{link.name}</span>
-            </Button>
+            </StyledLink>
           ))}
       </div>
     </section>

--- a/src/Components/StyledLink.js
+++ b/src/Components/StyledLink.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import PropTypes from 'prop-types'
+import 'primereact/button/button.min.css'
+
+function StyledLink({ children, className = '', ...props }) {
+  const classNames = ['p-button p-component', className].join(' ')
+  return (
+    <a className={classNames} {...props}>
+      {children}
+    </a>
+  )
+}
+
+StyledLink.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+}
+
+export default StyledLink


### PR DESCRIPTION
It's better for SEO, UX, and Accessibility

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #1016

## Changes proposed
Repaced button with links

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1025"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

