### PR TITLE
Add dark color to github icon in footer

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -25,7 +25,7 @@ function Footer() {
           className="mr-2"
           aria-label="LinkFree repository on GitHub"
         >
-          <GetIcons iconName="github" size={16} />
+          <GetIcons className="text-gray-900" iconName="github" size={16} />
         </Link>
         <span>v{version}</span>
       </p>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes #1072 

## Changes proposed

I added a dark color as className. But there is not black color as a utility (at least I did not find it). I added 'text-gray-900'.

One way to add black could be to use inline style as `style={{ color: #000 }}`.

There is a same icon in navbar. Should I change color of that one as well? Thoughts?

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![Screenshot (2)](https://user-images.githubusercontent.com/55027209/152780405-45148bf6-419f-4f90-a28d-8ce49427d216.png)
