### PR TITLE
Black GitHub icon

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -25,7 +25,7 @@ function Footer() {
           className="mr-2"
           aria-label="LinkFree repository on GitHub"
         >
-          <GetIcons iconName="github" size={16} />
+          <GetIcons className="text-gray-900" iconName="github" size={16} />
         </Link>
         <span>v{version}</span>
       </p>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -32,7 +32,7 @@ function Navbar({ items, start, end }) {
           className="mr-2"
           aria-label="LinkFree repository on GitHub"
         >
-          <GetIcons iconName="github" size={16} />
+          <GetIcons className="text-gray-900" iconName="github" size={16} />
         </Link>
 
         <div>v{version}</div>


### PR DESCRIPTION
Closes #1072 

## Changes proposed

Previously I added dark color to github icon in the footer.

This PR adds that same dark color for github icon in the navbar. 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

## Screenshots

Navbar icon now: 
![Screenshot (56)](https://user-images.githubusercontent.com/55027209/153566839-f189a815-c64d-4a0f-9335-1185d10f9999.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1116"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

