### PR TITLE
feat: add Infinite Scroll to home page

### DIFF
--- a/cypress/integration/common/actions.js
+++ b/cypress/integration/common/actions.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { Given } from 'cypress-cucumber-preprocessor/steps'
 
 Given('I open {string} page', (uri) => {
@@ -19,30 +20,34 @@ Given('I open {string} page', (uri) => {
   cy.visit(baseUrl + path)
 })
 
-When(`I click on {string}`, (text) => {
+When('I click on {string}', (text) => {
   cy.get(`a[href*="${text}"]`).click()
 })
 
-When(`I type {string} in {string}`, (type, location) => {
+When('I type {string} in {string}', (type, location) => {
   cy.get(location).type(type)
 })
 
-Then(`I should see {string} in the url`, (text) => {
+Then('I should see {string} in the url', (text) => {
   cy.url().should('include', text)
 })
 
-Then(`I see {string} as a link`, (text) => {
+Then('I see {string} as a link', (text) => {
   cy.get(`a[href*="${text}"]`).should('have.length', 1)
 })
 
-Then(`I see {string} text in section {string}`, (text, location) => {
+Then('I see {string} text in section {string}', (text, location) => {
   cy.get(location).should('contain', text)
 })
 
-Then(`I do not see {string} text in section {string}`, (text, location) => {
+Then('I do not see {string} text in section {string}', (text, location) => {
   cy.get(location).should('not.contain', text)
 })
 
-Then(`I see {string} item on the page`, (location) => {
+Then('I see {string} item on the page', (location) => {
   cy.get(location).should('be.visible')
+})
+
+Then('I scroll to the {string} of window', (scrollDirection) => {
+  cy.window().scrollTo(scrollDirection)
 })

--- a/cypress/integration/search.feature
+++ b/cypress/integration/search.feature
@@ -8,6 +8,7 @@ Feature: Search
 
     Scenario: Search with results
         Given I open "home" page
+        Then I scroll to the "bottom" of window
         Then I see "Eddie Jaoude" text in section "main"
         And I see "Kunal Verma" text in section "main"
         When I type "Eddie Jaoude" in ".search-section input"
@@ -16,6 +17,7 @@ Feature: Search
 
     Scenario: Search with no results
         Given I open "home" page
+        Then I scroll to the "bottom" of window
         Then I see "Eddie Jaoude" text in section "main"
         When I type "abced" in ".search-section input"
         Then I see "No users found, please try with another name." text in section "main"

--- a/cypress/integration/user.feature
+++ b/cypress/integration/user.feature
@@ -4,6 +4,7 @@ Feature: User profile page
 
     Scenario: Navigating to a user's page and check name
         Given I open "home" page
+        Then I scroll to the "bottom" of window
         Then I see "eddiejaoude" as a link
         When I click on "eddiejaoude"
         Then I should see "eddiejaoude" in the url

--- a/src/Components/Home/UserChip.js
+++ b/src/Components/Home/UserChip.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import { Chip } from 'primereact/chip'
+import { Avatar } from 'primereact/avatar'
+import { Badge } from 'primereact/badge'
+import utils from '../../utils'
+
+function UserChip({ user, ...props }) {
+  return (
+    <Link
+      to={user.username}
+      {...(props.lastElementRef && { ref: props.lastElementRef })}
+    >
+      <Chip
+        className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
+        template={
+          <>
+            <Avatar
+              image={user.avatar}
+              size="large"
+              className="p-overlay-badge"
+              onImageError={(error) => {
+                utils.setDefaultSVG(user.name, error)
+              }}
+            >
+              <Badge
+                value={user.linkCount > 9 ? '9+' : user.linkCount}
+                severity="info"
+                className="mr-3"
+              ></Badge>
+            </Avatar>
+            <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
+              {user.name}
+            </span>
+          </>
+        }
+      />
+    </Link>
+  )
+}
+
+UserChip.propTypes = {
+  user: PropTypes.object.isRequired,
+  lastElementRef: PropTypes.func,
+}
+
+export default UserChip


### PR DESCRIPTION
## Fixes Issue

Closes #1091

## Changes proposed

Revamp of the filtering logic to accommodate for the infinite scrolling functionality. Not fetching API for all the profiles rather only the profiles shown on screen.

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Note to reviewers

Some of the test cases were not passing as this PR revamps the rendering logic. 'search.feature' test was not able to find profile for 'Eddie Jaoude' as the profile was not rendering due to limited initial rendering due to infinite scroll. Similarly 'user.feature' was not able to find the profile due to same reason.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1201"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

