### PR TITLE
chore: add link to fediverse

### DIFF
--- a/public/data/indigo423.json
+++ b/public/data/indigo423.json
@@ -35,6 +35,11 @@
       "icon": "twitter"
     },
     {
+      "name": "Fediverse",
+      "url": "https://social.labmonkeys.space/@indigo",
+      "icon": "link"
+    },
+    {
       "name": "LinkedIn",
       "url": "https://www.linkedin.com/in/ronnytrommer/",
       "icon": "linkedin"


### PR DESCRIPTION
## Changes proposed

Added a link to my fediverse profile

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

