### PR TITLE
Persist profile type when returning from user page

### DIFF
--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Chip } from 'primereact/chip'
@@ -15,6 +15,15 @@ function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
   const [searchTerm, setSearchTerm] = useState('')
   const [filteredList, setFilteredList] = useState(list)
+
+  useEffect(() => {
+    if (localStorage.getItem('value') === null) {
+      typeHandler('all')
+    } else {
+      const value = localStorage.getItem('value')
+      typeHandler(value)
+    }
+  }, [])
 
   const typeHandler = (value) => {
     setProfileType(value)

--- a/src/Components/Home/filterProfileType.js
+++ b/src/Components/Home/filterProfileType.js
@@ -13,7 +13,10 @@ export default function ProfileTypeFilter({ profileType, typeHandler }) {
     <Dropdown
       value={profileType}
       options={profileTypes}
-      onChange={(e) => typeHandler(e.value)}
+      onChange={(e) => {
+        typeHandler(e.value)
+        localStorage.setItem('value', e.value)
+      }}
     />
   )
 }


### PR DESCRIPTION
## Fixes Issue

Proposed fix for #1285.

## Changes proposed

When the user filters the list, localStorage is used to save the value of the filter. When the user navigates back, the value is pulled from localStorage, thus persisting the filter.

If the filter was never used, the value defaults to 'all'.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

https://user-images.githubusercontent.com/40671491/168749037-a5733a9e-93ae-4beb-b706-ecadf62f77a7.mp4