### PR TITLE
remove profile images on homepage

### DIFF
--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -81,7 +81,7 @@ function Users({ list }) {
                 template={
                   <>
                     <Avatar
-                      image={user.avatar}
+                      // image={user.avatar}
                       size="large"
                       className="p-overlay-badge"
                       onImageError={(error) => {

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -3,13 +3,13 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Chip } from 'primereact/chip'
 // import { Avatar } from 'primereact/avatar'
-// import { Badge } from 'primereact/badge'
+import { Badge } from 'primereact/badge'
 import { Message } from 'primereact/message'
 
 import Navbar from '../Navbar'
 import Searchbar from './Searchbar'
 import ProfileTypeFilter from './filterProfileType'
-// import utils from '../../utils'
+import utils from '../../utils'
 
 function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
@@ -80,6 +80,20 @@ function Users({ list }) {
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
                 template={
                   <>
+                    <Chip
+                      // image={user.avatar}
+                      size="large"
+                      className="p-overlay-badge"
+                      onImageError={(error) => {
+                        utils.setDefaultSVG(user.name, error)
+                      }}
+                    >
+                      <Badge
+                        value={user.linkCount > 9 ? '9+' : user.linkCount}
+                        severity="info"
+                        className="mr-3"
+                      ></Badge>
+                    </Chip>
                     <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
                       {user.name}
                     </span>

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -9,7 +9,7 @@ import { Message } from 'primereact/message'
 import Navbar from '../Navbar'
 import Searchbar from './Searchbar'
 import ProfileTypeFilter from './filterProfileType'
-// import utils from '../../utils'
+import utils from '../../utils'
 
 function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
@@ -80,20 +80,20 @@ function Users({ list }) {
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
                 template={
                   <>
-                    {/* <Avatar
+                    <Chip
                       // image={user.avatar}
                       size="large"
                       className="p-overlay-badge"
                       onImageError={(error) => {
                         utils.setDefaultSVG(user.name, error)
                       }}
-                    > */}
-                    <Badge
-                      value={user.linkCount > 9 ? '9+' : user.linkCount}
-                      severity="info"
-                      className="mr-3"
-                    ></Badge>
-                    {/* </Avatar> */}
+                    >
+                      <Badge
+                        value={user.linkCount > 9 ? '9+' : user.linkCount}
+                        severity="info"
+                        className="mr-3"
+                      ></Badge>
+                    </Chip>
                     <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
                       {user.name}
                     </span>

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -2,14 +2,14 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Chip } from 'primereact/chip'
-import { Avatar } from 'primereact/avatar'
+// import { Avatar } from 'primereact/avatar'
 import { Badge } from 'primereact/badge'
 import { Message } from 'primereact/message'
 
 import Navbar from '../Navbar'
 import Searchbar from './Searchbar'
 import ProfileTypeFilter from './filterProfileType'
-import utils from '../../utils'
+// import utils from '../../utils'
 
 function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
@@ -80,20 +80,20 @@ function Users({ list }) {
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
                 template={
                   <>
-                    <Avatar
+                    {/* <Avatar
                       // image={user.avatar}
                       size="large"
                       className="p-overlay-badge"
                       onImageError={(error) => {
                         utils.setDefaultSVG(user.name, error)
                       }}
-                    >
-                      <Badge
-                        value={user.linkCount > 9 ? '9+' : user.linkCount}
-                        severity="info"
-                        className="mr-3"
-                      ></Badge>
-                    </Avatar>
+                    > */}
+                    <Badge
+                      value={user.linkCount > 9 ? '9+' : user.linkCount}
+                      severity="info"
+                      className="mr-3"
+                    ></Badge>
+                    {/* </Avatar> */}
                     <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
                       {user.name}
                     </span>

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -3,13 +3,13 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Chip } from 'primereact/chip'
 // import { Avatar } from 'primereact/avatar'
-import { Badge } from 'primereact/badge'
+// import { Badge } from 'primereact/badge'
 import { Message } from 'primereact/message'
 
 import Navbar from '../Navbar'
 import Searchbar from './Searchbar'
 import ProfileTypeFilter from './filterProfileType'
-import utils from '../../utils'
+// import utils from '../../utils'
 
 function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
@@ -80,20 +80,6 @@ function Users({ list }) {
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
                 template={
                   <>
-                    <Chip
-                      // image={user.avatar}
-                      size="large"
-                      className="p-overlay-badge"
-                      onImageError={(error) => {
-                        utils.setDefaultSVG(user.name, error)
-                      }}
-                    >
-                      <Badge
-                        value={user.linkCount > 9 ? '9+' : user.linkCount}
-                        severity="info"
-                        className="mr-3"
-                      ></Badge>
-                    </Chip>
                     <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
                       {user.name}
                     </span>

--- a/src/Components/Home/Users.js
+++ b/src/Components/Home/Users.js
@@ -2,14 +2,11 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Chip } from 'primereact/chip'
-// import { Avatar } from 'primereact/avatar'
-import { Badge } from 'primereact/badge'
 import { Message } from 'primereact/message'
 
 import Navbar from '../Navbar'
 import Searchbar from './Searchbar'
 import ProfileTypeFilter from './filterProfileType'
-import utils from '../../utils'
 
 function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
@@ -79,25 +76,9 @@ function Users({ list }) {
               <Chip
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
                 template={
-                  <>
-                    <Chip
-                      // image={user.avatar}
-                      size="large"
-                      className="p-overlay-badge"
-                      onImageError={(error) => {
-                        utils.setDefaultSVG(user.name, error)
-                      }}
-                    >
-                      <Badge
-                        value={user.linkCount > 9 ? '9+' : user.linkCount}
-                        severity="info"
-                        className="mr-3"
-                      ></Badge>
-                    </Chip>
-                    <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
-                      {user.name}
-                    </span>
-                  </>
+                  <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
+                    {user.name}
+                  </span>
                 }
               />
             </Link>


### PR DESCRIPTION
As mentioned in issue #1264, the front page currently loads
avatars from github, which can hit rate limits on the api.
This commit removes the images on from the front page

mentions #1264 


## Changes proposed

remove images from the front page

[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![Screen Shot 2022-05-19 at 10 06 11 PM](https://user-images.githubusercontent.com/52926724/169442497-1fb21387-31a5-4a39-bc88-279a311dd128.png)


## Note to reviewers


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1306"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

