### PR TITLE
fix : #1418 Mobile view error when text is to long

### DIFF
--- a/src/Components/Links.css
+++ b/src/Components/Links.css
@@ -46,3 +46,11 @@
     width: 90%;
   }
 }
+
+/* fixes issue in link button for long texts */
+@media screen and (max-width : 590px){
+  .p-button.p-button-outlined{
+    max-width: 85vw;
+    margin: auto;
+  }
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #1418 

## Changes proposed

[x] - Link Button with long text overflows from screen


## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Initial : 
![initial_eddie](https://user-images.githubusercontent.com/65801700/176836902-3f7546ad-2b90-4e3d-9d0b-9aa1d9a9fa5b.PNG)

After changes :
![final_eddie](https://user-images.githubusercontent.com/65801700/176836925-27ca0827-b92f-4026-8525-436012a91624.PNG) 


## Note to reviewers
This is my first contribution to the project. I have tried my best to follow the contribution guidelines.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1426"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

