### PR TITLE
Community profile badge

### DIFF
--- a/src/Components/Profile.css
+++ b/src/Components/Profile.css
@@ -1,3 +1,18 @@
+.communityBadge {
+  width: 12%;
+  margin: 0 0 20px 0;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #808080;
+  background-color: #f5f5f5;
+  border-color: #d2d2d2;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 50px;
+}
+
 .w-50 {
   max-width: 50vw;
   margin: 10px auto;
@@ -22,7 +37,14 @@
     margin: 2px auto;
     line-height: 20px;
   }
+
+  .communityBadge {
+    width: 40%;
+    font-size: 10px;
+    margin: 0 0 20px 0;
+  }
 }
+
 .share-icons {
   color: #333;
 }

--- a/src/Components/Profile.js
+++ b/src/Components/Profile.js
@@ -12,6 +12,14 @@ function Profile({ profile, username }) {
   const { name, bio, avatar } = profile
   return (
     <section>
+      {profile.type === 'community' && (
+        <div className="flex justify-content-center align-items-center">
+          <div className="communityBadge">
+            <h1>Community</h1>
+          </div>
+        </div>
+      )}
+
       <div className="flex justify-content-center align-items-center">
         <Avatar
           image={avatar}
@@ -27,7 +35,6 @@ function Profile({ profile, username }) {
           <p className="text-2xl font-bold mx-2 my-0">({username})</p>
         </div>
         <ShareProfile username={username} />
-
       </div>
       <div className="flex justify-content-center w-50">
         <p>{bio}</p>
@@ -40,6 +47,7 @@ Profile.propTypes = {
   username: PropTypes.string.isRequired,
   profile: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     bio: PropTypes.string.isRequired,
     avatar: PropTypes.string.isRequired,
   }),


### PR DESCRIPTION
## Fixes Issue
Fixes - [FEATURE] community profile pages marked as community #836 
> It is now possible to add types of community or personal to profiles. Community profiles should clearly mark somewhere at the top of the profile page that it belongs to a community, in order to differentiate them from personal pages.


<!-- Example: Closes #31 -->
Closes - #836 


## Changes proposed
Add a community tag on the top of the community profile.
- If a user visits the community profile, they will see the community badge on the top of the profile.
- Now users can differentiate between communities and user profiles.


<!-- List all the proposed changes in your PR -->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Before: 👇

![image](https://user-images.githubusercontent.com/44284877/177200743-b85baf20-b483-443a-8845-d14c5624ec9c.png)

After: 👇

![image](https://user-images.githubusercontent.com/44284877/177200588-54ccdad9-a3c0-4442-9849-8288595a7cd5.png)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
- Community badge: is having a simple design.
- If you have any new ideas to improve the design,
- or to change anything in the files or in the design, let me know. 
- Thanks.

<!-- Add notes to reviewers if applicable -->
