### PR TITLE
links property is now optional. generate.js doesn't break when links are not defined.

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -21,7 +21,7 @@ const output = profiles.map((profile) => ({
   name: profile.name,
   username: profile.username,
   avatar: profile.avatar,
-  linkCount: profile.links.length,
+  linkCount: profile.links ? profile.links.length : 0,
 }))
 
 fs.writeFileSync(writeDirectoryPath, JSON.stringify(output))

--- a/public/data/branrm.json
+++ b/public/data/branrm.json
@@ -1,0 +1,6 @@
+{
+  "name": "Brandon Rodriguez (SquatCub)",
+  "type": "personal",
+  "bio": "Computer systems engineer | Passionate about the code | Full Stack Dev | Front End Affinity",
+  "avatar": "https://github.com/squatcub.png"
+}

--- a/src/Components/UserProfile/ProfilePage.js
+++ b/src/Components/UserProfile/ProfilePage.js
@@ -10,10 +10,15 @@ function ProfilePage({ profile, username }) {
   const [milestones, setMilestones] = useState([])
 
   useEffect(() => {
-    const newLinks = profile.links?.map((link) => ({
-      ...link,
-      icon: link.icon?.toLowerCase(),
-    }))
+    const newLinks = []
+    if (profile.links) {
+      profile.links?.forEach((link) =>
+        newLinks.push({
+          ...link,
+          icon: link.icon?.toLowerCase(),
+        }),
+      )
+    }
     setLinks(newLinks)
 
     const newMilestones = profile.milestones?.map((milestone) => ({


### PR DESCRIPTION
## Fixes Issue

Closes [#1334](https://github.com/EddieHubCommunity/LinkFree/issues/1334)

## Changes proposed

<!-- List all the proposed changes in your PR -->
Makes a validation to check if links exists in ProfilePage.js, if true the array of links passes all his values, else an empty array is passed. Then in generate.js another validation is made to check if profile links exists, if true the length is returned, else a default zero is passed.
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
User profile data without links attribute
![Screen Shot 2022-07-06 at 14 36 49](https://user-images.githubusercontent.com/29969098/177629213-fa7e00a4-bf4a-471e-af1f-85c778f5e887.png)

Profile user view working without links attribute
<img width="1440" alt="Screen Shot 2022-07-06 at 14 34 54" src="https://user-images.githubusercontent.com/29969098/177628899-8080c13e-15db-4e98-bd74-402e4b310684.png">

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1458"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

