### PR TITLE
Add basic single user mode test case

### DIFF
--- a/cypress/integration/common/actions.js
+++ b/cypress/integration/common/actions.js
@@ -22,6 +22,10 @@ Given('I open {string} page', (uri) => {
   cy.visit(baseUrl + path)
 })
 
+Given('I use single user mode with {string}', (username) => {
+  cy.writeFile('src/config/user.json', `{ "username": "${username}" }`)
+})
+
 When('I click on {string}', (text) => {
   cy.get(`a[href*="${text}"]`).click()
 })
@@ -48,4 +52,12 @@ Then('I do not see {string} text in section {string}', (text, location) => {
 
 Then('I see {string} item on the page', (location) => {
   cy.get(location).should('be.visible')
+})
+
+Then('I change back to regular mode', () => {
+  // adding exact same contents back to file so it wont show up as changes on git
+  cy.writeFile(
+    'src/config/user.json',
+    `${JSON.stringify({ username: '' }, null, 2)}\n`,
+  )
 })

--- a/cypress/integration/singleuser.feature
+++ b/cypress/integration/singleuser.feature
@@ -1,0 +1,9 @@
+Feature: Single user page
+
+    Loading on single user mode
+
+    Scenario: Opening user page
+        Given I use single user mode with "eddiejaoude"
+        Given I open "home" page
+        And I see "Eddie Jaoude" text in section "h1"
+        Then I change back to regular mode


### PR DESCRIPTION
## Fixes Issue

Closes #1215 

## Changes proposed

- Added basic test case for singe user mode to make sure it loads properly.
- Made sure to put the exact original contents back to `user.json` file, so running tests does not affect git's workspace.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="975" alt="image" src="https://user-images.githubusercontent.com/35213792/178089266-1a635aba-9149-451b-b535-228243b50827.png">

## Note to reviewers

- I think it would be ideal to execute `Given('I use single user mode with {string}'` and `Then('I change back to regular mode'...` only once for all future scenarios within `singleuser.feature`, but I couldn't find the way to do it using `cypress-cucumber-preprocessor` syntax. I am willing to improve it if given any direction.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

