### PR TITLE
ci: add more workflows to reviewpad configuration

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -33,5 +33,11 @@ workflows:
         extra-actions:
           - $addLabel("kudos")
           - $info("Kudos for your 10th pull request! You are awesome")
-          
-      
+
+  - name: waiting-for-reviewers
+    always-run: true
+    if:
+      - rule: $reviewers() == []
+        extra-actions:
+          - '$info("A maintainer will review your pull request soon!")'
+          - '$addLabel("waiting-for-reviewers")'

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -8,6 +8,17 @@ labels:
   large:
     color: "8a2138"
 
+rules:
+  - name: check-for-file-name
+    description: Checks for the correct name
+    spec: $hasFileName($sprintf("public/data/%v.json", [$author()]))
+
+  - name: modifies-only-one-file
+    spec: $fileCount() == 1
+
+  - name: check-for-profile-addition
+    spec: $rule("check-for-file-name") && $rule("modifies-only-one-file")
+
 workflows:
   - name: label-pull-request-with-size
     always-run: true
@@ -44,6 +55,7 @@ workflows:
 
   - name: lint-commits
     description: Lint commit messages
+    always-run: true
     if:
       - rule: '!$hasLinearHistory()'
         extra-actions:
@@ -52,3 +64,17 @@ workflows:
         extra-actions:
           - '$commitLint()'
 
+  - name: add-label-for-chore-profile-addition
+    always-run: true
+    if:
+      - rule: $hasFilePattern("public/data/**")
+    then:
+      - '$addLabel("chore: profile-adition")'
+
+  - name: chore-profile-addition
+    description: Automates profile addition
+    always-run: true
+    if:
+      - rule: check-for-profile-addition
+    then:
+      - '$addLabel("LGTM")'

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -10,6 +10,7 @@ labels:
 
 workflows:
   - name: label-pull-request-with-size
+    always-run: true
     if:
       - rule: $size() <= 10
         extra-actions:
@@ -20,3 +21,17 @@ workflows:
       - rule: $size() > 30
         extra-actions:
           - $addLabel("large")
+
+  - name: first-time-contributor
+    always-run: true
+    if:
+      - rule: $pullRequestCountBy($author(), "all") == 1
+        extra-actions:
+          - '$commentOnce($sprintf("Welcome @%v! Thank you so much for your first pull request!", [$author()]))'
+      
+      - rule: $pullRequestCountBy($author(), "all") == 10
+        extra-actions:
+          - $addLabel("kudos")
+          - $info("Kudos for your 10th pull request! You are awesome")
+          
+      

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -41,3 +41,14 @@ workflows:
         extra-actions:
           - '$info("A maintainer will review your pull request soon!")'
           - '$addLabel("waiting-for-reviewers")'
+
+  - name: lint-commits
+    description: Lint commit messages
+    if:
+      - rule: '!$hasLinearHistory()'
+        extra-actions:
+          - '$warn("This pull request does not have linear history - please fix this!")'
+      - rule: 'true'
+        extra-actions:
+          - '$commitLint()'
+


### PR DESCRIPTION
This pull request adds more workflows to the reviewpad configuration with commit linting and waiting for reviewers.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1703"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

