### PR TITLE
fix: run prettier for data files

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -23,6 +23,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           commit_message: 'style: format files'


### PR DESCRIPTION
Now we have `path` in the triggers, I think we can always run this Action?

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1713"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

