### PR TITLE
fix: gh action format

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -3,10 +3,6 @@ on:
   push:
     paths:
       - 'public/data/**'
-  pull_request:
-    paths:
-      - 'public/data/**'
-  workflow_dispatch:
 
 jobs:
   format:


### PR DESCRIPTION
Only run the prettier action on the our branches, as it can't commit to a forked branch and will fail

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1715"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

