### PR TITLE
ci: release + deployment on cron

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Deploy
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Releases
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '00 00 * * *'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Releases
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron:  '00 00 * * *'
 
 jobs:
   changelog:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **Warning**
 >
-> Your profile will need to be deployed to appear, we try to collect a few together before deploying
+> Your profile will need to be deployed to appear, deployments happen at midnight UTC
 
 > **Warning**
 >


### PR DESCRIPTION
Create Release and then trigger Deploy every night at midnight UTC

Manual tiger moved to Release

No longer creates release for every push to `main`, will collect the days work up together and changelog will have more changes in it

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1776"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

