### PR TITLE
fix: lable name in reviewpad.yml

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -93,5 +93,5 @@ workflows:
     if:
       - rule: check-for-profile
     then:
-      - '$addLabel("hacktoberfest-invalid")'
+      - '$addLabel("invalid")'
       - '$commentOnce("Thank you for adding/editing your profile. Note this will not be included as part of Hacktoberfest.")'


### PR DESCRIPTION
Change label from `hacktoberfest-invalid` to `invalid`