### PR TITLE
fix: update hacktoberfest-invalid label to invalid

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -93,5 +93,5 @@ workflows:
     if:
       - rule: check-for-profile
     then:
-      - '$addLabel("hacktoberfest-invalid")'
+      - '$addLabel("invalid")'
       - '$commentOnce("Thank you for adding/editing your profile. Note this will not be included as part of Hacktoberfest.")'


### PR DESCRIPTION


## Changes proposed

Update the hacktoberfest-invalid label in the reviewpad file to just be invalid

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1850"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

