### PR TITLE
Bug 1324 graduation hat icon missing a hyphen

### DIFF
--- a/icons.md
+++ b/icons.md
@@ -1,3 +1,7 @@
+# Icons
+
+To use an icon, be sure to use the correct code in the `usage` column, not any other column.
+
 |   Socials   |    Usage    | Icons                                                                                                                                                        |    Socials     |     Usage      | Icons                                                                                                                                   |
 | :---------: | :---------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------: | :------------: | --------------------------------------------------------------------------------------------------------------------------------------- |
 |   Android   |   android   | <img src="https://user-images.githubusercontent.com/65664185/138502465-89cfadf2-6b54-4f3d-ac44-ceacdd4824ba.png" width=65% height=30%>                       |     Apple      |     apple      | <img src="https://user-images.githubusercontent.com/65664185/138502540-8e9b80bf-deae-4566-a41a-c63623e83c21.png" width=100% height=30%> |

--- a/src/Components/Icons/GetIcons.js
+++ b/src/Components/Icons/GetIcons.js
@@ -77,6 +77,7 @@ function GetIcons({ iconName, ...restProps }) {
       return <FaGitlab {...restProps} />
     case 'globe':
       return <FaGlobe {...restProps} />
+    case 'Graduation Hat':
     case 'graduation-hat':
       return <FaGraduationCap {...restProps} />
     case 'hackerrank':


### PR DESCRIPTION
## Fixes Issue

Resolves #1324

## Changes proposed

Add `Graduation Hat` as a valid icon alongside `graduation hat`, because users have mistaken the icon code for the icon name.
Also, add a notice to icons.md clarifying how to use icons.

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- - Changes to icons.md
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1890"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

