### PR TITLE
fix: NextJs user preview card name size

### DIFF
--- a/components/user/UserPreview.js
+++ b/components/user/UserPreview.js
@@ -4,7 +4,7 @@ import Link from "next/link";
 export default function UserPreview({ profile }) {
   return (
     <Link href={`/${profile.username}`}>
-      <a className="flex flex-col gap-x-6 rounded md:rounded-full md:flex-row border-2 border-gray-200 hover:border-gray-500 p-4 my-2">
+      <a className="flex flex-col gap-x-4 rounded md:rounded-full md:flex-row border-2 border-gray-200 hover:border-gray-500 p-4 my-2">
         <div className="flex items-center gap-5">
           <div className="min-w-[5rem]">
             <Image
@@ -15,7 +15,7 @@ export default function UserPreview({ profile }) {
               className="rounded-full"
             />
           </div>
-          <h3 className="text-2xl font-bold md:hidden">
+          <h3 className="text-xl font-bold md:hidden">
             {profile.name} {profile.views && <span>({profile.views})</span>}
           </h3>
         </div>


### PR DESCRIPTION


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #1984 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
Changes name text size from text-2xl to text-xl in user preview card in NextJs

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
- [x ] This PR does not contain plagiarized content.
- [x ] The title of my pull request is a short description of the requested changes.

## Screenshots
![Screenshot (59)](https://user-images.githubusercontent.com/54969439/196177872-47f5c96e-a018-42e0-a6cb-011e8f3e1c0c.png)

![Screenshot (36)](https://user-images.githubusercontent.com/54969439/196177929-47c9de8e-a437-499c-aa5f-0223f01bb951.png)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/1985"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

