### PR TITLE
Fix dark mode profile share icon 

### DIFF
--- a/src/Components/ShareProfile.js
+++ b/src/Components/ShareProfile.js
@@ -3,11 +3,13 @@ import GetIcons from './Icons/GetIcons'
 import PropTypes from 'prop-types'
 import ShareIcon from './ShareIcon'
 import { Toast } from 'primereact/toast'
+import { useTheme } from '../ThemeContext'
 
 export default function ShareProfile({ username }) {
   const [show, setShow] = useState(false)
   const toast = useRef(null)
   const profileUrl = location.href
+  const darkTheme = useTheme()
 
   const CopyLink = () => {
     navigator.clipboard.writeText(profileUrl)
@@ -24,7 +26,10 @@ export default function ShareProfile({ username }) {
       <Toast ref={toast} />
 
       <div onClick={() => setShow(!show)}>
-        <GetIcons iconName="shareprofile" />
+        <GetIcons
+          className={`${darkTheme ? 'text-white' : 'text-gray-900'}`}
+          iconName="shareprofile"
+        />
       </div>
 
       {show


### PR DESCRIPTION
## Changes proposed

  Profile Share icon on profile page was not visible in the dark mode, now it is fixed.

## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Changes are highlighted in red color:
Before changes:
![1](https://user-images.githubusercontent.com/73838737/196825182-1092b5e7-8afd-4953-97e9-0570a7a2f52a.png)
After changes:
![2](https://user-images.githubusercontent.com/73838737/196825246-d5c7750d-4de7-4903-b10d-b50c4e383e4b.png)

## Note to reviewers

  It is a small UI bug fix.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2002"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

