### PR TITLE
fix(#1999) : color issue in the dark mode

### DIFF
--- a/src/Components/Search/Search.css
+++ b/src/Components/Search/Search.css
@@ -9,7 +9,7 @@ a {
 .p-chip:hover {
   transform: scale(1.1);
   background: linear-gradient(145deg, #c8cbcf, #eef2f6);
-  box-shadow: 8px 8px 15px #bdc0c4, -8px -8px 15px #ffffff;
+  color: black !important;
 }
 
 .p-chip .p-avatar img {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Closes https://github.com/EddieHubCommunity/LinkFree/issues/1999

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

### Changes proposed

When the user hovers over the items in the list, box shadow of white was causing eye strain, and the text was not visible. Hence as part of this PR I have removed the box shadow and updated the color to black on hover which will fix the above issue. 

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

Before fix:


![image](https://user-images.githubusercontent.com/23126394/197328665-69135969-5dc2-40f7-b0ce-408af64442a1.png)

After fix:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/23126394/197328559-1b77c6b9-146f-43ee-87ef-b80f30022fcb.png">




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2014"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

