### PR TITLE
(feat #1995) : Cross icon feature to close shareprofile popup

### DIFF
--- a/src/Components/ShareProfile.css
+++ b/src/Components/ShareProfile.css
@@ -1,0 +1,11 @@
+.cross-icon .pi {
+  position: absolute;
+  right: 1rem;
+  top: 0.9rem;
+  border-radius: 0.3rem;
+  border-color: #80808092;
+}
+
+.cross-icon:hover {
+  color: #80808092;
+}

--- a/src/Components/ShareProfile.js
+++ b/src/Components/ShareProfile.js
@@ -3,6 +3,7 @@ import GetIcons from './Icons/GetIcons'
 import PropTypes from 'prop-types'
 import ShareIcon from './ShareIcon'
 import { Toast } from 'primereact/toast'
+import './ShareProfile.css'
 
 export default function ShareProfile({ username }) {
   const [show, setShow] = useState(false)
@@ -22,7 +23,6 @@ export default function ShareProfile({ username }) {
   return (
     <div className="flex justify-content-center">
       <Toast ref={toast} />
-
       <div onClick={() => setShow(!show)}>
         <GetIcons iconName="shareprofile" />
       </div>
@@ -56,6 +56,12 @@ export default function ShareProfile({ username }) {
               label="Share on LinkedIn"
               iconName="linkedin"
             />
+            <div className="cross-icon">
+              <i
+                className="pi pi-times border-solid hidden sm:inline-flex"
+                onClick={() => setShow(null)}
+              ></i>
+            </div>
             <a
               className="mx-4 sm:mx-5"
               role="button"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #1995 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
 ShareProfile Popup doesn't have close button or cross icon to close the popup box. I have added this feature which closes popup while clicking upon.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![cross-icon](https://user-images.githubusercontent.com/63870995/197345481-bca28533-2bee-4ad4-a817-027b779897b4.gif)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
i have hidden this feature for mobile view , its for large to medium size screens .

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2020"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

