### PR TITLE
add : adding profile picture in chip

### DIFF
--- a/cypress/integration/search.feature
+++ b/cypress/integration/search.feature
@@ -13,8 +13,6 @@ Feature: Search
 
     Scenario: Search with results
         Given I open "search" page
-        Then I see "Eddie Jaoude" text in section "main"
-        And I see "Kunal Verma" text in section "main"
         When I type "Eddie Jaoude" in ".search-section input"
         Then I see "Eddie Jaoude" text in section "main"
         And I do not see "Kunal Verma" text in section "main"

--- a/cypress/integration/search.feature
+++ b/cypress/integration/search.feature
@@ -19,7 +19,6 @@ Feature: Search
 
     Scenario: Search with no results
         Given I open "search" page
-        Then I see "Eddie Jaoude" text in section "main"
         When I type "abced" in ".search-section input"
         Then I see "No users found, please try with another name." text in section "main"
         And I do not see "Eddie Jaoude" text in section "main"

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -10,7 +10,6 @@ import { useTheme } from '../../ThemeContext'
 
 function Search() {
   const [list, setList] = useState([])
- 
   const toast = useRef(null)
   const darkTheme = useTheme()
 

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -31,7 +31,6 @@ function Search() {
           life: 5000,
         })
       })
-      
   }, [])
 
   return (

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -1,7 +1,6 @@
 import './Search.css'
 import React, { useState, useEffect, useRef } from 'react'
 import Navbar from '../Navbar'
-import Placeholders from './Placeholders'
 import GetIcons from '../Icons/GetIcons'
 import Users from './Users'
 import { Link } from 'react-router-dom'

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -10,7 +10,7 @@ import { useTheme } from '../../ThemeContext'
 
 function Search() {
   const [list, setList] = useState([])
-  const [skeleton, setskeleton] = useState(true)
+  const [skeleton, setskeleton] = useState(false)
   const toast = useRef(null)
   const darkTheme = useTheme()
 

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -10,7 +10,7 @@ import { useTheme } from '../../ThemeContext'
 
 function Search() {
   const [list, setList] = useState([])
-  const [skeleton, setskeleton] = useState(false)
+ 
   const toast = useRef(null)
   const darkTheme = useTheme()
 
@@ -32,11 +32,7 @@ function Search() {
           life: 5000,
         })
       })
-      .finally(() => {
-        setTimeout(() => {
-          setskeleton(false)
-        }, 500)
-      })
+      
   }, [])
 
   return (
@@ -56,7 +52,7 @@ function Search() {
       </header>
       <main>
         <Toast ref={toast} />
-        {skeleton ? <Placeholders list={list} /> : <Users list={list} />}
+         <Users list={list} />
       </main>
     </>
   )

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -77,7 +77,7 @@ function Users({ list }) {
              <Chip
                 style={theme}
                 label={
-                  user.name.length > 22
+                  user.name.length > 25
                     ? user.name.slice(-22) + ' ...'
                     : user.name
                 }

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -77,7 +77,7 @@ function Users({ list }) {
              <Chip
                 style={theme}
                 label={
-                  user.name.length > 25
+                  user.name.length > 20
                     ? user.name.slice(-22) + ' ...'
                     : user.name
                 }

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -11,6 +11,7 @@ function Users({ list }) {
   const [profileType, setProfileType] = useState('all')
   const [searchTerm, setSearchTerm] = useState('')
   const [filteredList, setFilteredList] = useState(list)
+  const [length, setlength] = useState(0)
   const darkTheme = useTheme()
 
   const theme = {
@@ -43,7 +44,8 @@ function Users({ list }) {
   }
 
   const searchHandler = (value) => {
-    setSearchTerm(value || '')
+    setlength(value.length)
+    setSearchTerm(value)
     setFilteredList(
       list
         .filter((User) =>
@@ -60,7 +62,7 @@ function Users({ list }) {
   }
 
   return (
-    <>
+     <>
       <div className="mb-2 flex justify-content-center align-items-center">
         <Searchbar searchTerm={searchTerm} searchHandler={searchHandler} />
         <label className="p-2">Profile Type</label>
@@ -69,12 +71,13 @@ function Users({ list }) {
           typeHandler={typeHandler}
         />
       </div>
-      <div className="user-list flex flex-wrap justify-content-center">
+     
+      {length>=3 && <div className="user-list flex flex-wrap justify-content-center">
         {!!filteredList &&
           filteredList.length > 0 &&
           filteredList.map((user, key) => (
-            <Link to={user.username} key={`avatar-${key}`}>
-             <Chip
+            <Link  to={user.username} key={`avatar-${key}`}>
+              <Chip
                 style={theme}
                 label={
                   user.name.length > 20
@@ -82,7 +85,7 @@ function Users({ list }) {
                     : user.name
                 }
                 className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
-                image={user.avatar}
+               image={user.avatar}
               />
             </Link>
           ))}
@@ -92,9 +95,9 @@ function Users({ list }) {
               severity="error"
               text="No users found, please try with another name."
             />
-          </div>
+          </div> 
         )}
-      </div>
+      </div>}
     </>
   )
 }

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -75,7 +75,7 @@ function Users({ list }) {
         {!!filteredList &&
           filteredList.length > 0 &&
           filteredList.map((user, key) => (
-            <Link  to={user.username} key={`avatar-${key}`}>
+            <Link to={user.username} key={`avatar-${key}`}>
               <Chip
                 style={theme}
                 label={
@@ -94,7 +94,7 @@ function Users({ list }) {
               severity="error"
               text="No users found, please try with another name."
             />
-          </div> 
+          </div>
         )}
       </div>}
     </>

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -74,14 +74,15 @@ function Users({ list }) {
           filteredList.length > 0 &&
           filteredList.map((user, key) => (
             <Link to={user.username} key={`avatar-${key}`}>
-              <Chip
+             <Chip
                 style={theme}
-                className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
-                template={
-                  <span className="text-overflow-ellipsis white-space-nowrap overflow-hidden">
-                    {user.name}
-                  </span>
+                label={
+                  user.name.length > 22
+                    ? user.name.slice(-22) + ' ...'
+                    : user.name
                 }
+                className="m-2 w-16rem px-3 py-2 transition-all transition-duration-300"
+                image={user.avatar}
               />
             </Link>
           ))}

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -70,9 +70,8 @@ function Users({ list }) {
           profileType={profileType}
           typeHandler={typeHandler}
         />
-      </div>
-     
-      {length>=3 && <div className="user-list flex flex-wrap justify-content-center">
+      </div>   
+      {length >= 3 && <div className="user-list flex flex-wrap justify-content-center">
         {!!filteredList &&
           filteredList.length > 0 &&
           filteredList.map((user, key) => (

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -70,7 +70,7 @@ function Users({ list }) {
           profileType={profileType}
           typeHandler={typeHandler}
         />
-      </div>   
+      </div>
       {length >= 3 && <div className="user-list flex flex-wrap justify-content-center">
         {!!filteredList &&
           filteredList.length > 0 &&


### PR DESCRIPTION



## Changes proposed
1) profile picture for particular user added in chips in the search page 
2) in chip element "templet" attribute removed and using default "label" attribute and also using "image" attribute for profile picture

3.chips will come after user enters 3 or more characters in search bar this will solve github api limit issue.


- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![9d1b628f-bd4e-43cf-9e25-b0ace9ca4a29](https://user-images.githubusercontent.com/97971066/197398631-0e45664d-9657-4156-bea7-96cf0f3289f4.jpg)


![new](https://user-images.githubusercontent.com/97971066/197398477-81228c29-b0fc-4eff-a3d3-fec18d45de32.jpg)

it s also presentable for long names :

<img width="304" alt="Screenshot 2022-10-23 at 6 26 10 PM" src="https://user-images.githubusercontent.com/97971066/197398515-54886eb5-354f-4822-a884-18713d9c5ab1.png">



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2024"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

