### PR TITLE
Made Profile names  visible on hovering in dark mode

### DIFF
--- a/src/Components/Profile.css
+++ b/src/Components/Profile.css
@@ -20,7 +20,6 @@
   width: 50px;
   cursor: pointer;
   font-size: 23px;
-  color: rgb(68, 68, 68);
   transition: all 0.2s ease-in-out;
 }
 

--- a/src/Components/Search/Search.css
+++ b/src/Components/Search/Search.css
@@ -8,7 +8,6 @@ a {
 
 .p-chip:hover {
   transform: scale(1.1);
-  background: linear-gradient(145deg, #c8cbcf, #eef2f6);
   box-shadow: 8px 8px 15px #bdc0c4, -8px -8px 15px #ffffff;
 }
 

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -48,7 +48,7 @@ function Search() {
               <GetIcons
                 iconName="arrowLeft"
                 size={20}
-                className={`${darkTheme ? 'text-white' : 'text-gray-900'}`}
+                className={`${darkTheme ? 'text-white' : 'text-black'}`}
               />
             </Link>
           }

--- a/src/Components/Search/Searchbar.js
+++ b/src/Components/Search/Searchbar.js
@@ -20,7 +20,7 @@ const Searchbar = ({ searchHandler, searchTerm }) => {
   const theme = {
     backgroundColor: `${darkTheme ? '#333333' : 'white'}`,
     border: `${darkTheme ? 'none' : '1px solid #ced4da'}`,
-    color: `${darkTheme ? 'white' : 'grey'}`,
+    color: `${darkTheme ? 'white' : 'black'}`,
   }
 
   return (

--- a/src/Components/Search/Users.js
+++ b/src/Components/Search/Users.js
@@ -15,7 +15,7 @@ function Users({ list }) {
 
   const theme = {
     backgroundColor: `${darkTheme ? '#333333' : '#dee2e6'}`,
-    color: `${darkTheme ? 'white' : 'grey'}`,
+    color: `${darkTheme ? 'white' : 'black'}`,
   }
 
   const typeHandler = (value) => {


### PR DESCRIPTION
## Fixes Issue 
#1928 

## Changes proposed

I have made the profile names visible on hovering in dark mode and also made the **share icon** visible.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![Screenshot (168)](https://user-images.githubusercontent.com/91705825/197401268-691c1e11-417d-48f5-9cdb-fe882aa13141.png)
![Screenshot (169)](https://user-images.githubusercontent.com/91705825/197401271-b694f7b0-2406-4aa3-83e4-de7e69847428.png)
![Screenshot (170)](https://user-images.githubusercontent.com/91705825/197401273-17cafe3f-9b59-4e45-96cd-aa5b19ac1519.png)


## Note to reviewers

I closed the previous PR that I raised for this issue due to some error and raised this one.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2026"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

