### PR TITLE
add test for popular profile search

### DIFF
--- a/tests/popular.spec.js
+++ b/tests/popular.spec.js
@@ -1,0 +1,4 @@
+test.fixme("Popular profile view", async ({ page }) => {
+  // 1. click on the popular profile
+  // 2. check wheather the most popular profile is at thee top of the profile list
+});

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -40,8 +40,3 @@ test.fixme("After search click profile", async ({ page }) => {
   // 2. click on searched profile
   // 3. check profile is displayed
 });
-
-test.fixme("Popular profile view", async ({ page }) => {
-  // 1. click on the popular profile
-  // 2. check wheather the most popular profile is at thee top of the profile list
-});

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -40,3 +40,8 @@ test.fixme("After search click profile", async ({ page }) => {
   // 2. click on searched profile
   // 3. check profile is displayed
 });
+
+test.fixme("Popular profile view", async ({ page }) => {
+  // 1. click on the popular profile
+  // 2. check wheather the most popular profile is at thee top of the profile list
+});


### PR DESCRIPTION
## Fixes Issue
Closes #2084 

## Changes proposed
- skeleton for testing wheather the popular profile is displayed at the top in the popular page.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
 
##Screenshot:

![popuular](https://user-images.githubusercontent.com/54346106/199058807-c46ce097-8653-4e9d-af47-052ae0a2635d.png)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2088"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

