### PR TITLE
chore: remove hacktoberfest-exclude labler

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -12,10 +12,6 @@ labels:
     color: '8a2138'
 
 rules:
-  - name: check-for-profile
-    description: Checks for profile changed
-    spec: $hasFilePattern("public/data/**")
-
   - name: check-for-file-name
     description: Checks for the correct author
     spec: $hasFileName($sprintf("public/data/%v.json", [$author()]))

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -86,12 +86,3 @@ workflows:
       - rule: check-for-version2
     then:
       - '$addLabel("v2")'
-
-  - name: hacktoberfest exclude
-    description: Exclude pull requests from Hacktoberfest that are profile changes
-    always-run: true
-    if:
-      - rule: check-for-profile
-    then:
-      - '$addLabel("invalid")'
-      - '$commentOnce("Thank you for adding/editing your profile. Note this will not be included as part of Hacktoberfest.")'


### PR DESCRIPTION
due hacktoberfest is over I would suggest removing the hacktoberfest invalid labler by reviewpad due the label `invalid` is not serving value anymore

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2097"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

