### PR TITLE
Allow using the "rel" attribute for specific link types

### DIFF
--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -36,6 +36,7 @@ function Links({ links }) {
                     ? 'white'
                     : colors[link.icon],
               }}
+              rel={link.rel ? link.rel : null}
               href={link.url}
             >
               <IconContext.Provider
@@ -57,6 +58,7 @@ function Links({ links }) {
               onMouseOut={MouseOut}
               className={`p-3 my-2 p-button-outlined ${link.icon}`}
               style={{ color: colors.globe }}
+              rel={link.rel ? link.rel : null}
               href={link.url}
             >
               <IconContext.Provider


### PR DESCRIPTION
## Fixes Issue

One example is if you want to use LinkFree as your "home page", and want to add a link to your Mastodon profile, adding `rel="me"` in the link allows to make your mastodon account "verified" (similar to what twitter blue does but with less certainty and safety).

Since "rel" is a standard attribute, instead of just a flag for `rel="me"`, this PR allows supporting **any** value for `rel`, up to the user 👍

For instance, I'm using it on my self-hosted LinkFree instance on https://links.piers.tech and it works great 🚀

## Changes proposed

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

N/A

## Note to reviewers

N/A
