### PR TITLE
Add MongoDB .env error handler

### DIFF
--- a/config/mongo.js
+++ b/config/mongo.js
@@ -1,5 +1,11 @@
-import mongoose from "mongoose";
-import * as fs from "fs";
+import mongoose from 'mongoose';
+import * as fs from 'fs';
+
+if (!process.env.LINKFREE_MONGO_CONNECTION_STRING) {
+  throw new Error(
+    'Please define LINKFREE_MONGO_CONNECTION_STRING to .env.local'
+  );
+}
 
 let hasConnection = false;
 const connectMongo = async () => {
@@ -10,15 +16,15 @@ const connectMongo = async () => {
     // DigitalOcean Apps has cert as environment variable but Mongo needs a file path
     // Write Mongo cert file to disk
     if (process.env.CA_CERT) {
-      fs.writeFileSync("cert.pem", process.env.CA_CERT);
+      fs.writeFileSync('cert.pem', process.env.CA_CERT);
     }
 
     mongoose.connect(process.env.LINKFREE_MONGO_CONNECTION_STRING);
     hasConnection = true;
-    console.log("DB connected");
+    console.log('DB connected');
   } catch (err) {
     hasConnection = false;
-    console.error("DB Not connected", err);
+    console.error('DB Not connected', err);
   }
 };
 

--- a/config/mongo.js
+++ b/config/mongo.js
@@ -1,9 +1,9 @@
-import mongoose from 'mongoose';
-import * as fs from 'fs';
+import mongoose from "mongoose";
+import * as fs from "fs";
 
 if (!process.env.LINKFREE_MONGO_CONNECTION_STRING) {
   throw new Error(
-    'Please define LINKFREE_MONGO_CONNECTION_STRING to .env.local'
+    "Please define LINKFREE_MONGO_CONNECTION_STRING to .env.local"
   );
 }
 
@@ -16,15 +16,15 @@ const connectMongo = async () => {
     // DigitalOcean Apps has cert as environment variable but Mongo needs a file path
     // Write Mongo cert file to disk
     if (process.env.CA_CERT) {
-      fs.writeFileSync('cert.pem', process.env.CA_CERT);
+      fs.writeFileSync("cert.pem", process.env.CA_CERT);
     }
 
     mongoose.connect(process.env.LINKFREE_MONGO_CONNECTION_STRING);
     hasConnection = true;
-    console.log('DB connected');
+    console.log("DB connected");
   } catch (err) {
     hasConnection = false;
-    console.error('DB Not connected', err);
+    console.error("DB Not connected", err);
   }
 };
 

--- a/config/mongo.js
+++ b/config/mongo.js
@@ -3,7 +3,7 @@ import * as fs from "fs";
 
 if (!process.env.LINKFREE_MONGO_CONNECTION_STRING) {
   throw new Error(
-    "Please define LINKFREE_MONGO_CONNECTION_STRING to .env.local"
+    "Please define the LINKFREE_MONGO_CONNECTION_STRING environment variable (if local add to .env file)"
   );
 }
 


### PR DESCRIPTION
## Changes proposed

Added a check in `config/mongo.js` to check if the `LINKFREE_MONGO_CONNECTION_STRING` mongo connection string is present inside `env.local` :

```js
// config/mongo.js
if (!process.env.LINKFREE_MONGO_CONNECTION_STRING) {
  throw new Error(
    "Please define LINKFREE_MONGO_CONNECTION_STRING to .env.local"
  );
}
```

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

Hello 😁


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2193"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

