### PR TITLE
fix: refactor search page structure

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -61,11 +61,6 @@ export default function Search({ users }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className="flex flex-col px-6 align-center">
-        {notFound && (
-          <h2 className="bg-red-200 text-red-600 border-2 border-red-600 p-5 my-5 text-xl">
-            {notFound} not found
-          </h2>
-        )}
         <h1 className="text-4xl mb-4  font-bold">Search</h1>
         <input
           placeholder="Search users (minimum 3 characters)"
@@ -73,6 +68,11 @@ export default function Search({ users }) {
           name="keyword"
           onChange={(e) => filterData(e.target.value)}
         />
+        {notFound && (
+          <h2 className="bg-red-200 text-red-600 border-2 border-red-600 p-5 my-5 text-xl">
+            {notFound} not found
+          </h2>
+        )}
         <ul>
           {filteredUsers.map((user) => (
             <li key={user.username}>

--- a/pages/search.js
+++ b/pages/search.js
@@ -24,20 +24,27 @@ export default function Search({ users }) {
   const { username } = router.query;
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [notFound, setNotFound] = useState();
+  const [threeOrMore, setThreeOrMore] = useState();
+
+  let results = [];
 
   useEffect(() => {
     if (username) {
       setNotFound(username);
+      setThreeOrMore(false);
     }
   }, []);
 
   const filterData = (value) => {
     if (value.length <= 3) {
+      setThreeOrMore(false);
+      setFilteredUsers(results);
       setNotFound();
     }
 
     if (value.length >= 3) {
-      const results = users.filter((user) =>
+      setThreeOrMore(true);
+      results = users.filter((user) =>
         user.name.toLowerCase().includes(value.toLowerCase())
       );
 
@@ -63,7 +70,7 @@ export default function Search({ users }) {
       <div className="flex flex-col px-6 align-center">
         <h1 className="text-4xl mb-4  font-bold">Search</h1>
         <input
-          placeholder="Search users (minimum 3 characters)"
+          placeholder="Search users"
           className="border-2 hover:border-orange-600 transition-all duration-250 ease-linear rounded px-6 py-2"
           name="keyword"
           onChange={(e) => filterData(e.target.value)}
@@ -71,6 +78,11 @@ export default function Search({ users }) {
         {notFound && (
           <h2 className="bg-red-200 text-red-600 border-2 border-red-600 p-5 my-5 text-xl">
             {notFound} not found
+          </h2>
+        )}
+        {!threeOrMore && (
+          <h2 className="bg-yellow-200 text-yellow-600 border-2 border-yellow-600 p-5 my-5 text-xl">
+            You have to enter at least 3 characters to search for a user.
           </h2>
         )}
         <ul>


### PR DESCRIPTION
**Updated:**

![image](https://user-images.githubusercontent.com/30869493/201115367-d8a27da3-7d3b-4065-8c86-a7dbdee0a35c.png)

user not found under the search bar.

**Old:**
![image](https://user-images.githubusercontent.com/30869493/201115562-0eebb113-9a4a-4ae7-b045-26cab46d7bcf.png)



This change prevents that the search bar is jumping on the page when the error message appears

Further added a warning message if the search string is less than 3 characters
![image](https://user-images.githubusercontent.com/30869493/201122368-4bb5c06a-29c0-4b88-9dcd-3dcb51c85a67.png)

Remove the results list if the search string is less than 3 characters