### PR TITLE
Fix aria-expanded

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -78,7 +78,7 @@ export default function Navbar() {
                 type="button"
                 className="bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
                 aria-controls="mobile-menu"
-                aria-expanded="false"
+                aria-expanded={isOpen}
               >
                 <span className="sr-only">Open main menu</span>
                 <svg

--- a/pages/index.js
+++ b/pages/index.js
@@ -108,7 +108,6 @@ export default function Home({ data }) {
         </div>
         <a
           href="https://github.com/EddieHubCommunity/LinkFree/discussions"
-          legacybehavior
           rel="noopener noreferrer"
           target="_blank"
         >


### PR DESCRIPTION
## Changes proposed
Fix aria-expanded on mobile menu to match the open / closed status of the menu.
Removed a `legacybehavior` attribute on an anchor tag that is not relevant and produces a warning.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

