### PR TITLE
ci: change the GitHub Token to PAT

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Prettier
         run: npx prettier --write data/*.json
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: format files"


### PR DESCRIPTION
## Changes proposed

- change the GitHub Token to PAT (`GH_PAT`) 


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2321"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

