### PR TITLE
feat: create Page component to unify padding and sizing of the main pages

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -1,0 +1,7 @@
+export default function Page({ children }) {
+  return (
+    <div className="max-w-7xl mx-auto flex flex-col p-6 align-center">
+      {children}
+    </div>
+  );
+}

--- a/pages/[username].js
+++ b/pages/[username].js
@@ -10,6 +10,7 @@ import UserLinks from "../components/user/UserLinks";
 import UserMilestones from "../components/user/UserMilestones";
 import UserTestimonials from "../components/user/UserTestimonials";
 import UserEvents from "../components/user/UserEvents";
+import Page from "../components/Page";
 
 export async function getServerSideProps(context) {
   let data = {};
@@ -98,7 +99,7 @@ export default function User({ users, data, BASE_URL }) {
         <meta property="og:image" content={data.avatar} />
       </Head>
 
-      <div className="mx-auto container px-6 mt-6">
+      <Page>
         <UserProfile data={data} BASE_URL={BASE_URL} />
 
         <UserTabs tabs={tabs} setTabs={setTabs} />
@@ -125,7 +126,7 @@ export default function User({ users, data, BASE_URL }) {
           tabs.find((tab) => tab.name === "Events").current && (
             <UserEvents data={data} />
           )}
-      </div>
+      </Page>
     </>
   );
 }

--- a/pages/[username].js
+++ b/pages/[username].js
@@ -109,19 +109,16 @@ export default function User({ users, data, BASE_URL }) {
             <UserLinks data={data} BASE_URL={BASE_URL} />
           )}
 
-        <div className="my-8"></div>
         {tabs.find((tab) => tab.name === "Milestones") &&
           tabs.find((tab) => tab.name === "Milestones").current && (
             <UserMilestones data={data} />
           )}
 
-        <div className="my-8"></div>
         {tabs.find((tab) => tab.name === "Testimonials") &&
           tabs.find((tab) => tab.name === "Testimonials").current && (
             <UserTestimonials data={data} users={users} BASE_URL={BASE_URL} />
           )}
 
-        <div className="my-8"></div>
         {tabs.find((tab) => tab.name === "Events") &&
           tabs.find((tab) => tab.name === "Events").current && (
             <UserEvents data={data} />

--- a/pages/events.js
+++ b/pages/events.js
@@ -2,6 +2,7 @@ import Head from "next/head";
 
 import Event from "../components/Event";
 import Alert from "../components/Alert";
+import Page from "../components/Page";
 
 export async function getServerSideProps(context) {
   let events = [];
@@ -25,7 +26,7 @@ export default function Events({ events }) {
         <meta name="description" content="Search LinkFree user directory" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="flex flex-col px-6 align-center">
+      <Page>
         {!events.length && <Alert type="info" message="No events found" />}
         <ul>
           {events.map((event) => (
@@ -34,7 +35,7 @@ export default function Events({ events }) {
             </li>
           ))}
         </ul>
-      </div>
+      </Page>
     </>
   );
 }

--- a/pages/popular.js
+++ b/pages/popular.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import UserCard from "../components/user/UserCard";
+import Page from "../components/Page";
 
 export async function getServerSideProps(context) {
   let data = [];
@@ -28,8 +29,7 @@ export default function Popular({ data }) {
         />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-
-      <div className="p-5">
+      <Page>
         <h1 className="text-4xl mb-4  font-bold">Popular Profiles</h1>
         <ul className="flex flex-wrap gap-3 justify-center mt-[3rem]">
           {data.map((profile) => (
@@ -38,7 +38,7 @@ export default function Popular({ data }) {
             </li>
           ))}
         </ul>
-      </div>
+      </Page>
     </>
   );
 }

--- a/pages/search.js
+++ b/pages/search.js
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import UserCard from "../components/user/UserCard";
 import Alert from "../components/Alert";
+import Page from "../components/Page";
 
 export async function getServerSideProps(context) {
   let users = [];
@@ -67,7 +68,7 @@ export default function Search({ users }) {
         <meta name="description" content="Search LinkFree user directory" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="flex flex-col px-6 align-center">
+      <Page>
         <h1 className="text-4xl mb-4  font-bold">Search</h1>
         <input
           placeholder="Search users"
@@ -89,7 +90,7 @@ export default function Search({ users }) {
             </li>
           ))}
         </ul>
-      </div>
+      </Page>
     </>
   );
 }


### PR DESCRIPTION
## Fixes Issue #2288 

## Changes proposed

As described in #2288 there is some inconsistency between the main pages.
This PR adds a `Page` component that can be used on the main pages to make sure the styling is consistent.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![popular](https://user-images.githubusercontent.com/7253929/206260559-7ac9d15c-c7ad-4600-a7b0-f4e239f160c9.png)

![search](https://user-images.githubusercontent.com/7253929/206260527-6015e6a7-807e-40b0-a0d3-61fc7bc58c26.png)

![events](https://user-images.githubusercontent.com/7253929/206260487-a6554f4b-7e09-46d3-819d-88ab48b3850c.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2336"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

