### PR TITLE
fix: user tabs click on small devices

### DIFF
--- a/components/user/UserTabs.js
+++ b/components/user/UserTabs.js
@@ -4,7 +4,7 @@ export default function UserTabs({ tabs, setTabs }) {
     e.preventDefault();
     setTabs(
       tabs.map((tab) =>
-        tab.name === value
+        tab.name === e.target?.value || tab.name === value
           ? { ...tab, current: true }
           : { ...tab, current: false }
       )
@@ -19,7 +19,7 @@ export default function UserTabs({ tabs, setTabs }) {
         <select
           id="tabs"
           name="tabs"
-          onChange={(e) => changeTab(e.target.value)}
+          onChange={changeTab}
           className="block w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
           defaultValue={tabs.find((tab) => tab.current).name}
         >


### PR DESCRIPTION
Closes #2333 

## Fixes Issue

Fixes the user tabs issue on small devices. Clicking on the select's option now e.preventDefault() method does not throw any console error and the page content will change accordingly. 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [] My change requires changes to the documentation.
- [] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.
