### PR TITLE
Fix text contrast  ratio on UserLink

### DIFF
--- a/components/user/UserLink.js
+++ b/components/user/UserLink.js
@@ -31,9 +31,9 @@ export default function UserLink({
       target="_blank"
       rel="noopener noreferrer"
       onClick={clickLink}
-      className="rounded-full border-2 border-gray-200 hover:shadow-xl p-4 my-2 w-full content-start flex flex-row gap-4 items-center user-link"
+      className="rounded-full border-2 border-gray-200 hover:border-[color:var(--hover-color)] hover:shadow-xl p-4 my-2 w-full content-start flex flex-row gap-4 items-center"
       style={{
-        "--user-link-color": colors[link.icon]
+        "--hover-color": colors[link.icon]
       }}
     >
       <span style={{color: colors[link.icon]}}>

--- a/components/user/UserLink.js
+++ b/components/user/UserLink.js
@@ -31,12 +31,14 @@ export default function UserLink({
       target="_blank"
       rel="noopener noreferrer"
       onClick={clickLink}
-      className="rounded-full border-2 border-gray-200 hover:border-gray-500 hover:shadow-xl p-4 my-2 w-full content-start flex flex-row gap-4 items-center"
+      className="rounded-full border-2 border-gray-200 hover:shadow-xl p-4 my-2 w-full content-start flex flex-row gap-4 items-center user-link"
       style={{
-        color: colors[link.icon],
+        "--user-link-color": colors[link.icon]
       }}
     >
-      <Icon name={link.icon} />
+      <span style={{color: colors[link.icon]}}>
+        <Icon name={link.icon}/>
+      </span>
       <span className="grow">{link.name}</span>
       {displayStatsPublic && <span>{clicks}</span>}
     </a>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,6 +15,11 @@ a {
   box-sizing: border-box;
 }
 
+.user-link:hover {
+  --user-link-color: #808080;
+  border-color: var(--user-link-color);
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,11 +15,6 @@ a {
   box-sizing: border-box;
 }
 
-.user-link:hover {
-  --user-link-color: #808080;
-  border-color: var(--user-link-color);
-}
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Fixes Issue
Fixes UserLink issue for #2382 

## Changes proposed

Use icon color for icon & hover border
Use black for text color

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Current link style:

![UserLink-before](https://user-images.githubusercontent.com/35927536/208256080-12da715e-4bb3-49d3-bcad-200fbd8d8e93.png)

New link style:

![UserLink-after](https://user-images.githubusercontent.com/35927536/208256107-ffb7f776-8ba5-4602-8cc5-6ef96e4f3026.png)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

