### PR TITLE
issue #2637 fix

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,10 @@ const nextConfig = {
     minimumCacheTTL: 60 * 60 * 24,
     remotePatterns: [
       {
+        protocol: "http",
+        hostname: "github.com",
+      },
+      {
         protocol: "https",
         hostname: "github.com",
       },


### PR DESCRIPTION
## Fixes Issue
Fixed issue that arises by using `http` for getting the GitHub avatar. Check #2637 issue for details

## Changes proposed
Changed `HTTP` to `HTTPS` in 4 files of the `data/`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/59391441/210486668-505674ac-3557-4a29-8176-d72ddf49b269.png)

After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59391441/210486652-f96e60b1-3412-4562-8bce-bc498c8c3fc4.png">



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2638"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

