### PR TITLE
Updated icon reference to Pradumna's website

### DIFF
--- a/data/Pradumnasaraf.json
+++ b/data/Pradumnasaraf.json
@@ -7,7 +7,7 @@
   "socials": [
     { "icon": "FaTwitter", "url": "https://twitter.com/pradumna_saraf" },
     { "icon": "FaGithub", "url": "https://github.com/Pradumnasaraf" },
-    { "icon": "website", "url": "https://pradumnasaraf.dev" }
+    { "icon": "FaLink", "url": "https://pradumnasaraf.dev" }
   ],
   "testimonials": ["eddiejaoude"],
   "avatar": "https://github.com/Pradumnasaraf.png",


### PR DESCRIPTION
**Changes Proposed**:

`icon="website"`
to
`icon="FaLink"`


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

