### PR TITLE
GitHub Action testimonial should valid json before committing file #2659

### DIFF
--- a/.github/workflows/testimonial.yml
+++ b/.github/workflows/testimonial.yml
@@ -16,7 +16,14 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/testimonial.yml
           body: ${{ github.event.issue.body }}
-      - run: cat ${HOME}/issue-parser-result.json
+      - name: Install jq
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+        run: |
+          npm install -g jq
+      - name: Validate JSON
+        run: jq . ${HOME}/issue-parser-result.json
       - name: current date
         id: date
         uses: Kaven-Universe/github-action-current-date-time@v1


### PR DESCRIPTION
## Fixes Issue

Closes #2659 

## Changes proposed

- Add an extra step to validate JSON before merging a testimonial

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://user-images.githubusercontent.com/19922556/210545403-dc021b04-0049-42ba-844e-4d394118d21c.png)

## Note to reviewers

> **Note** Testing GitHub Actions has always been a little bit flakey for me, and I know I need to spend some time figuring it out. I'm pretty sure this works correctly, if not it shouldn't be off by much because it works here locally.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2660"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

