### PR TITLE
test: popular page navigation from navbar

### DIFF
--- a/tests/popular.spec.js
+++ b/tests/popular.spec.js
@@ -1,11 +1,12 @@
 // @ts-check
 import { test, expect } from "@playwright/test";
 
-test.fixme(
+test(
   "Click on popular profile in navbar navigates to popular page",
   async ({ page }) => {
-    // 1. click on popular nav link
-    // 2. check if it takes us to the popular page
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Popular' }).click();
+    await expect(page).toHaveURL('/popular');
   }
 );
 


### PR DESCRIPTION
## Changes proposed

Add a playwright test that:
- clicks on the popular link in the navbar
- checks if the page navigated to is the popular profiles page

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="762" alt="2023-01-04_142514" src="https://user-images.githubusercontent.com/1948858/210566383-f39b4906-c88f-499a-8d83-847ca2153b17.png">

