### PR TITLE
docs: add usage of hexcode in milestones docs

### DIFF
--- a/pages/docs/how-to-guides/milestones.mdx
+++ b/pages/docs/how-to-guides/milestones.mdx
@@ -21,7 +21,7 @@ _If you need help on how to edit this file, please see the [Editing guide](/docs
     "title": "Started Freelancing",
     "date": "May 2010",
     "icon": "FaDollarSign",
-    "color": "grey",
+    "color": "grey", // or #808080
     "description": "Started my own business",
     "url": "https://www.eddiejaoude.io/"
 }
@@ -33,7 +33,7 @@ _If you need help on how to edit this file, please see the [Editing guide](/docs
 | title       | Main heading of the milestone                               |
 | date        | Month and Year                                              |
 | icon        | What icon would you like displayed with this milestone      |
-| color       | What color would you like this milestone to be displayed in |
+| color       | What color would you like this milestone to be displayed in. Use hex codes or name of the color |
 | description | More details about the milestone, this can include markdown |
 | url         | Where can people learn more about the milestone             |
 


### PR DESCRIPTION
## Fixes Issue
PR for issue #2840. Correction in `pages/docs/how-to-guides/milestones.mdx`

Closes #2840 


## Changes proposed

```diff
- 24. "color": "grey", 
+ 24. "color": "grey", // or #808080
```

```diff
- 36.  | color       | What color would you like this milestone to be displayed in |
+ 36. | color       | What color would you like this milestone to be displayed in. Use hex codes or name of the color |
```


## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/59391441/211194001-8a562fab-ed3a-467b-8eb1-29e654b32975.png">


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2861"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

