### PR TITLE
fixed the random usercards and popular usercards allignment 

### DIFF
--- a/components/user/UserCard.js
+++ b/components/user/UserCard.js
@@ -7,7 +7,7 @@ export default function UserCard({ profile }) {
   return (
     <Link
       href={`/${profile.username}`}
-      className="flex flex-col items-center border-2 max-w-[14rem] h-[17rem] overflow-hidden rounded-lg border-gray-200 p-4 gap-3 hover:border-orange-600"
+      className="flex flex-col items-center border-2 w-[14rem] h-[17rem] overflow-hidden rounded-lg border-gray-200 p-4 gap-3 hover:border-orange-600"
     >
       <div className="flex justify-center relative">
         <FallbackImage


### PR DESCRIPTION


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #2866 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
changed the `userCard` width to be fixed `14rem`, previously it was `max-width: 14rem` and this was causing the cards with lesser bio content to sharing and take lesser spacing causing the alignment issue

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [x ] The title of my pull request is a short description of the requested changes.

## Screenshots
Before: 
![Screenshot from 2023-01-08 17-33-38](https://user-images.githubusercontent.com/95094057/211214965-48cfaf54-79a7-440b-b602-1b84ff2e8228.png)

After:
![Screenshot from 2023-01-08 17-34-37](https://user-images.githubusercontent.com/95094057/211214944-e099bec4-2573-4c04-b6e6-b1b86b9dcb78.png)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/2896"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

