### PR TITLE
docs: updated docker command and image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Your profile will have links to your social media and content. You can also add 
 
 Here is an example of a LinkFree Profile https://linkfree.eddiehub.io/eddiejaoude
 
-![Example profile on LinkFree](https://user-images.githubusercontent.com/624760/207048057-0f8cc74f-cc50-4cb3-b1a9-7e37f1a66d2c.png)
+![Example profile on LinkFree](https://user-images.githubusercontent.com/51878265/211527055-d90f94f5-f6a9-44a7-be0f-905f5e45429e.png)
 
 ## 🛠️ Quickstart
 
@@ -63,11 +63,11 @@ This will allow you to run your favourite IDE but not have to install any depend
 #### Prerequisites
 
 - Docker
-- Docker Compose
+- [Docker Compose](https://github.com/docker/compose) V2.
 
 #### Commands
 
-1. `docker-compose up`
+1. `docker compose up` 
 
 ### 🙂 How to add YOUR Profile
 


### PR DESCRIPTION
- chnage the example profile image to the latest one
- Fix the docker command. That was one for compose - v1, which is now deprecated

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3070"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

