### PR TITLE
docs: fix typo 

### DIFF
--- a/pages/docs/how-to-guides/milestones.mdx
+++ b/pages/docs/how-to-guides/milestones.mdx
@@ -3,7 +3,7 @@ import ClipboardCopy from "../../../components/ClipboardCopy"
 
 ## Milestones
 
-Demostrate the highlights of your career by adding Milestones to your Profile. This could when you got your first job to reaching 100k followers/subscribers.
+Demostrate the highlights of your career by adding Milestones to your Profile. This could be when you got your first job to reaching 100k followers/subscribers.
 
 ![Example of LinkFree Milestones](https://user-images.githubusercontent.com/624760/209209651-87e4f75f-425d-4837-82d0-84030e82ae6f.png)
 

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -140,7 +140,7 @@ export default function DocsIndex() {
           name: "Milestones",
           path: "/docs/how-to-guides/milestones",
           description:
-            "Demostrate the highlights of your career by adding Milestones to your Profile. This could when you got your first job to reaching 100k followers/subscribers.",
+            "Demostrate the highlights of your career by adding Milestones to your Profile. This could be when you got your first job to reaching 100k followers/subscribers.",
           category: {
             name: "beginner",
             color: "bg-green-100 text-green-800",


### PR DESCRIPTION
[DOCS] Typo in docs under Milestones closes #3063 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3158"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

