### PR TITLE
Update events.mdx

### DIFF
--- a/pages/docs/how-to-guides/events.mdx
+++ b/pages/docs/how-to-guides/events.mdx
@@ -15,7 +15,7 @@ All future events also appear on the Events page for the app.
 
 1. Create a folder that matches your GitHub username in the `data` directory and then in that folder create another folder called `events`. For example `data/eddiejaoude/events/`
 
-2. In your folder add a `json` file with any name you like. We recommend putting the date first and then appending it with the event name. For example `2023-09-13-javacsript-conference.json`.
+2. In your folder add a `json` file with any name you like. We recommend putting the date first and then appending it with the event name. For example `2023-09-13-javascript-conference.json`.
 
 _If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
 


### PR DESCRIPTION
fixed spelling mistake
javacsript -> javascript

closes #3366 

## Fixes Issue



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3374"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

