### PR TITLE
make the word 'here' clickable instead full link

### DIFF
--- a/components/layouts/DocsLayout.js
+++ b/components/layouts/DocsLayout.js
@@ -17,13 +17,13 @@ export default function DocsLayout({ children, title }) {
         <p>
           Here you should find everything you need from getting started with
           creating your Profile to more advanced topics. You can contribute to
-          our documentation and find the files here{" "}
+          our documentation and find the files{" "}
           <a
             href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs"
             target="_blank"
             rel="noreferrer"
           >
-            https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs
+            here
           </a>
         </p>
         <div className="float-none my-0 max-w-[1440px] prose">


### PR DESCRIPTION
this PR closes issue #3358

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3379"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

