### PR TITLE
ci: remove the push part from the JSON check workflow

### DIFF
--- a/.github/workflows/json-check.yml
+++ b/.github/workflows/json-check.yml
@@ -1,9 +1,6 @@
 name: JSON check
 
 on:
-  push:
-    paths:
-      - "data/**.json"
   pull_request:
     paths:
       - "data/**.json"


### PR DESCRIPTION
## Changes proposed

Remove the `push:` part from the **JSON check** workflow because the `main` branch is protected, and push operations can't be done. So, everything will go via PR, and PR is already been checked by the workflow. 

**Technically, the workflow's push part will never run.**

Part removed:

```yaml
push:
  paths:
    - "data/**.json"
```