### PR TITLE
ci: remove the push part form community workflow

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,7 +1,5 @@
 on:
   fork:
-  push:
-    branches: [main]
   issues:
     types: [opened]
   issue_comment:

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,3 +1,4 @@
+name: Greeting
 on:
   fork:
   issues:


### PR DESCRIPTION
- Remove the push: part from the workflow because the main branch is protected, and push operations can't be done. Also, it will stop the messages on the temp branches created by Deploy and Releases.

- Added a name to the workflow for better understanding. Currently, it shows the file name with the path.
<img width="1361" alt="Screenshot 2023-01-14 at 12 26 57 AM" src="https://user-images.githubusercontent.com/51878265/212397867-0caab111-2ddd-4d43-8fc8-47ad6e531fa6.png">



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

