### PR TITLE
[FIX] fixes the links view count not being sorted

### DIFF
--- a/components/user/UserLinks.js
+++ b/components/user/UserLinks.js
@@ -8,10 +8,10 @@ export default function UserLinks({ BASE_URL, data }) {
       {data.links && (
         <div className="flex flex-col items-center w-full">
           {data.links &&
-            data.links.map((link, index) => (
+            data.links.map((link) => (
               <UserLink
                 BASE_URL={BASE_URL}
-                key={index}
+                key={link.name}
                 link={link}
                 username={data.username}
                 displayStatsPublic={data.displayStatsPublic}

--- a/components/user/UserLinks.js
+++ b/components/user/UserLinks.js
@@ -2,6 +2,8 @@ import UserLink from "./UserLink";
 import Alert from "../Alert";
 
 export default function UserLinks({ BASE_URL, data }) {
+  data.links = data.links.map((link, i) => ({ id: i, ...link }));
+
   return (
     <>
       {!data.links && <Alert type="info" message="No links found" />}
@@ -11,7 +13,7 @@ export default function UserLinks({ BASE_URL, data }) {
             data.links.map((link) => (
               <UserLink
                 BASE_URL={BASE_URL}
-                key={link.name}
+                key={link.id}
                 link={link}
                 username={data.username}
                 displayStatsPublic={data.displayStatsPublic}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

closes #3434 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
This was happening due to not having the correct key property while mapping over the link

<!-- List all the proposed changes in your PR -->
Instead of using `index` as key, changed it to `link.name`
the Link has `name, icon and url` values in it, the name seemed the most optimal

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

## Screenshots

![Screenshot from 2023-01-15 22-01-45](https://user-images.githubusercontent.com/95094057/212553518-850aba71-26e1-436f-8b37-3b8c315cac2c.png)

![image](https://user-images.githubusercontent.com/95094057/212553514-bc783d11-c3a6-4227-af1e-9d7f5ddac6e6.png)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->

If having `link.name` as the key is not the appropriate option, we can add an `id` on each link before mapping over it like this
```
  data.links = data.links.map((link, i) => ({ id: i, ...link }));
```
By this, each link will also have a unique `id` field which can be used as a key


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3496"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

