### PR TITLE
`OG` add twitter card and og image

### DIFF
--- a/pages/[username].js
+++ b/pages/[username].js
@@ -84,13 +84,55 @@ export default function User({ data, BASE_URL }) {
         <meta name="description" content={data.bio} />
         <link rel="icon" href="/favicon.ico" />
 
-        <meta property="og:title" content={data.name} />
-        <meta property="og:type" content="image/png" />
+        {/* twitter card meta tags */}
         <meta
+          key="twitter-title"
+          name="twitter:title"
+          content={data.name}
+        />
+        <meta
+          key="twitter-description"
+          name="twitter:description"
+          content={data.bio}
+        />
+        <meta
+          key="twitter-card"
+          name="twitter:card"
+          content="summary_large_image"
+        />
+        <meta
+          key="twitter-image-src"
+          name="twitter:image:src"
+          content={`https://linkfreeog.codinasion.org/${data.username}`}
+        />
+        {/* og card meta tags */}
+        <meta
+          key="og-title"
+          property="og:title"
+          content={data.name}
+        />
+        <meta
+          key="og-description"
+          property="og:description"
+          content={data.bio}
+        />
+        <meta
+          key="og-url"
           property="og:url"
           content={`https://linkfree.eddiehub.io/${data.username}`}
         />
-        <meta property="og:image" content={data.avatar} />
+        <meta key="og-site-name" property="og:site_name" content="LinkFree" />
+        <meta key="og-type" property="og:type" content="website" />
+        <meta
+          key="og-image"
+          property="og:image"
+          content={`https://linkfreeog.codinasion.org/${data.username}`}
+        />
+        <meta
+          key="og-image-alt"
+          property="og:image:alt"
+          content={data.bio}
+        />
       </Head>
 
       <Page>

--- a/pages/index.js
+++ b/pages/index.js
@@ -190,6 +190,56 @@ export default function Home({ total, today }) {
           content="Open Source alternative to LinkTree"
         />
         <link rel="icon" href="/favicon.ico" />
+
+        {/* twitter card meta tags */}
+        <meta
+          key="twitter-title"
+          name="twitter:title"
+          content="LinkFree - connect to your audience with a single link"
+        />
+        <meta
+          key="twitter-description"
+          name="twitter:description"
+          content="Open Source alternative to LinkTree"
+        />
+        <meta
+          key="twitter-card"
+          name="twitter:card"
+          content="summary_large_image"
+        />
+        <meta
+          key="twitter-image-src"
+          name="twitter:image:src"
+          content="https://linkfreeog.codinasion.org"
+        />
+        {/* og card meta tags */}
+        <meta
+          key="og-title"
+          property="og:title"
+          content="LinkFree - connect to your audience with a single link"
+        />
+        <meta
+          key="og-description"
+          property="og:description"
+          content="Open Source alternative to LinkTree"
+        />
+        <meta
+          key="og-url"
+          property="og:url"
+          content="https://linkfree.eddiehub.io/"
+        />
+        <meta key="og-site-name" property="og:site_name" content="LinkFree" />
+        <meta key="og-type" property="og:type" content="website" />
+        <meta
+          key="og-image"
+          property="og:image"
+          content="https://linkfreeog.codinasion.org"
+        />
+        <meta
+          key="og-image-alt"
+          property="og:image:alt"
+          content="LinkFree - connect to your audience with a single link"
+        />
       </Head>
       <main>
         <div className="bg-gray-50 mb-8 p-8 drop-shadow-md">


### PR DESCRIPTION
## Changes proposed

- Better OG images

## Why

While sharing `LinkFree` links on Discord or Twitter, I noticed that the LinkFree OG can be improved.

I have some prior experience with creating dynamic OG images. So, I created one for LinkFree 🤗 

## How

`Repo`: https://github.com/codinasion/LinkFree-OG

OG images are created by Github actions and updates every 6/12 hours (not decided yet!)

The OG images are provided through an `API` 👉🏻 `https://linkfreeog.codinasion.org`

There are two separate APIs, one for `LinkFree` and the other for `User Profile`

LinkFree: https://linkfreeog.codinasion.org
Profile: https://linkfreeog.codinasion.org/<GITHUB_USERNAME>

## Showcase

![LinkFree](https://linkfreeog.codinasion.org/)
![Profile](https://linkfreeog.codinasion.org/eddiejaoude)
![Another Profile](https://linkfreeog.codinasion.org/Pradumnasaraf)

## What difference it makes (on Discord)

<p align="middle">
<img src="https://user-images.githubusercontent.com/54644599/212772903-62927ad3-23c4-4a18-bc7c-a009aa3ef63a.png" alt="" width="400px" />
<img src="https://user-images.githubusercontent.com/54644599/212772910-8db4f14b-497c-46a1-9207-bc7e4b0d2456.png" alt="" width="400px" />
</p>

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3567"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

