### PR TITLE
Changed PowerOff icon to FaSuperpowers icon

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { FaMoneyBillAlt } from "react-icons/fa";
-import { FaSuperpowers } from "react-icons/fa";
+import { FaRocket } from "react-icons/fa";
 
 export default function Footer() {
   return (
@@ -9,7 +9,7 @@ export default function Footer() {
         href="https://github.com/EddieHubCommunity/LinkFree"
         className="text-gray-500 hover:text-gray-600 flex justify-center space-x-6 md:order-2 gap-2"
       >
-        <FaSuperpowers className="h-6 w-6" aria-hidden="true" />
+        <FaRocket className="h-6 w-6" aria-hidden="true" />
         Powered by EddieHub
       </Link>
       <Link

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { FaMoneyBillAlt } from "react-icons/fa";
-import { FaPowerOff } from "react-icons/fa";
+import { FaSuperpowers } from "react-icons/fa";
 
 export default function Footer() {
   return (
@@ -9,7 +9,7 @@ export default function Footer() {
         href="https://github.com/EddieHubCommunity/LinkFree"
         className="text-gray-500 hover:text-gray-600 flex justify-center space-x-6 md:order-2 gap-2"
       >
-        <FaPowerOff className="h-6 w-6" aria-hidden="true" />
+        <FaSuperpowers className="h-6 w-6" aria-hidden="true" />
         Powered by EddieHub
       </Link>
       <Link


### PR DESCRIPTION
## Changes proposed

The PowerOff icon beside **Powered by Eddiefub** looks a bit odd as it resembles the shutdown icon.

![image](https://user-images.githubusercontent.com/48781286/212533805-f59c1d43-64c3-4f60-8d26-4249d2f85af9.png)

A better alternative would be to use the FaSuperpowers icon, which will bring a positive perspective.

![image](https://user-images.githubusercontent.com/48781286/212533679-4d5a415d-ba9a-496b-a4b4-87a1e16bd8d1.png)

## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3474"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/3782"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

