### PR TITLE
feat: links more accessible with custom link component (#2523) (#3276)

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../components/Link";
 import { FaMoneyBillAlt } from "react-icons/fa";
 import { FaRocket } from "react-icons/fa";
 

--- a/components/Link.js
+++ b/components/Link.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import NextLink from 'next/link'
+
+export default function Link({ children, className, rel, ...restProps }) {
+    return (
+        <NextLink
+            rel={rel ? rel : "noreferrer"}
+            className={className ? className : "text-blue-600 underline decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid"}
+            {...restProps}
+        >
+            {children}
+        </NextLink>
+    )
+}

--- a/components/Link.js
+++ b/components/Link.js
@@ -1,14 +1,18 @@
-import React from 'react'
-import NextLink from 'next/link'
+import React from "react";
+import NextLink from "next/link";
 
 export default function Link({ children, className, rel, ...restProps }) {
-    return (
-        <NextLink
-            rel={rel ? rel : "noreferrer"}
-            className={className ? className : "text-blue-600 underline decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid"}
-            {...restProps}
-        >
-            {children}
-        </NextLink>
-    )
+  return (
+    <NextLink
+      rel={rel ? rel : "noreferrer"}
+      className={
+        className
+          ? className
+          : "text-blue-600 underline decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid"
+      }
+      {...restProps}
+    >
+      {children}
+    </NextLink>
+  );
 }

--- a/components/Tag.js
+++ b/components/Tag.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../components/Link";
 import { abbreviateNumber } from "../services/utils/abbreviateNumbers";
 
 export default function Tag({ name, total }) {

--- a/components/event/EventCard.js
+++ b/components/event/EventCard.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../Link";
 import { FaMicrophoneAlt } from "react-icons/fa";
 import {
   MdOutlineOnlinePrediction,

--- a/components/event/EventTabs.js
+++ b/components/event/EventTabs.js
@@ -1,3 +1,5 @@
+import Link from "../Link";
+
 export function EventTabs({ tabs, eventType, setEventType }) {
   const classNames = (...classes) => classes.filter(Boolean).join(" ");
   const changeTab = (e, value) => {
@@ -30,7 +32,7 @@ export function EventTabs({ tabs, eventType, setEventType }) {
         <div className="border-b border-gray-200">
           <nav className="-mb-px flex" aria-label="Tabs">
             {tabs.map((tab) => (
-              <a
+              <Link
                 key={tab.key}
                 href={tab.href}
                 onClick={(e) => changeTab(e, tab.key)}
@@ -54,7 +56,7 @@ export function EventTabs({ tabs, eventType, setEventType }) {
                 <span>
                   {tab.title} ({tab.total})
                 </span>
-              </a>
+              </Link>
             ))}
           </nav>
         </div>

--- a/components/layouts/DocsLayout.js
+++ b/components/layouts/DocsLayout.js
@@ -2,7 +2,6 @@ import Head from "next/head";
 import Page from "../Page";
 import Link from "../../components/Link";
 
-
 export default function DocsLayout({ children, title }) {
   return (
     <>
@@ -18,10 +17,22 @@ export default function DocsLayout({ children, title }) {
         <h1 className="text-4xl mb-4 font-bold">Documentation</h1>
         <p>
           Here you should find everything you need from getting started with
-          creating your Profile to more advanced topics. We welcome contributions, check out the&nbsp;
-          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree">LinkFree Repo</Link> and the&nbsp;
-          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs">documentation source</Link> and the&nbsp;
-          on GitHub for more information.
+          creating your Profile to more advanced topics. We welcome
+          contributions, check out the&nbsp;
+          <Link
+            target="_blank"
+            href="https://github.com/EddieHubCommunity/LinkFree"
+          >
+            LinkFree Repo
+          </Link>
+          &nbsp; and the&nbsp;
+          <Link
+            target="_blank"
+            href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs"
+          >
+            documentation source
+          </Link>{" "}
+          and the&nbsp; on GitHub for more information.
         </p>
         <div className="float-none my-0 max-w-[1440px] prose">
           <div className="flex flex-grow flex-row">

--- a/components/layouts/DocsLayout.js
+++ b/components/layouts/DocsLayout.js
@@ -1,5 +1,7 @@
 import Head from "next/head";
 import Page from "../Page";
+import Link from "../../components/Link";
+
 
 export default function DocsLayout({ children, title }) {
   return (
@@ -16,16 +18,10 @@ export default function DocsLayout({ children, title }) {
         <h1 className="text-4xl mb-4 font-bold">Documentation</h1>
         <p>
           Here you should find everything you need from getting started with
-          creating your Profile to more advanced topics. You can contribute to
-          our documentation and find the files here{" "}
-          <a
-            href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs"
-            target="_blank"
-            rel="noreferrer"
-            className="text-sky-700 break-words"
-          >
-            https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs
-          </a>
+          creating your Profile to more advanced topics. We welcome contributions, check out the&nbsp;
+          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree">LinkFree Repo</Link> and the&nbsp;
+          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs">documentation source</Link> and the&nbsp;
+          on GitHub for more information.
         </p>
         <div className="float-none my-0 max-w-[1440px] prose">
           <div className="flex flex-grow flex-row">

--- a/components/navbar/NavLink.js
+++ b/components/navbar/NavLink.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../Link";
 
 export default function NavLink({ path, item, mode, setIsOpen }) {
   let className =

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -163,7 +163,7 @@ export default function Navbar() {
               <div className="flex items-center md:ml-6">
                 <span className="text-gray-400">v{app.version}</span>
                 <div className="ml-3 relative">
-                  <a
+                  <Link
                     href="https://github.com/EddieHubCommunity/LinkFree"
                     aria-current="page"
                     target="_blank"
@@ -177,7 +177,7 @@ export default function Navbar() {
                     >
                       <FaGithub />
                     </IconContext.Provider>
-                  </a>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
 import NavLink from "./NavLink";
-import Link from "next/link";
+import Link from "../Link";
 import app from "../../config/app.json";
 import Image from "next/legacy/image";
 import { FaGithub } from "react-icons/fa";

--- a/components/user/UserCard.js
+++ b/components/user/UserCard.js
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "../Link";
 import ReactMarkdown from "react-markdown";
 import { abbreviateNumber } from "../../services/utils/abbreviateNumbers";
 import FallbackImage from "../FallbackImage";

--- a/components/user/UserLink.js
+++ b/components/user/UserLink.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import getIcon from "../Icon";
 import colors from "../../config/icons.json";
+import Link from "../Link";
 
 export default function UserLink({
   BASE_URL,
@@ -13,7 +14,7 @@ export default function UserLink({
   const DisplayIcon = getIcon(link.icon);
 
   return (
-    <a
+    <Link
       href={`${BASE_URL}/api/users/${username}/links/${encodeURIComponent(
         link.url
       )}`}
@@ -30,6 +31,6 @@ export default function UserLink({
       </span>
       <span className="grow">{link.name}</span>
       {displayStatsPublic && <span>{clicks}</span>}
-    </a>
+    </Link>
   );
 }

--- a/components/user/UserMilestone.js
+++ b/components/user/UserMilestone.js
@@ -1,5 +1,6 @@
 import { ReactMarkdown } from "react-markdown/lib/react-markdown";
 import getIcon from "../Icon";
+import Link from "../Link";
 
 export default function UserMilestone({ milestone, isGoal }) {
   const DisplayIcon = getIcon(milestone.icon);
@@ -12,7 +13,7 @@ export default function UserMilestone({ milestone, isGoal }) {
         borderColor: milestone.color,
       }}
     >
-      <a
+      <Link
         href={milestone.url}
         key={milestone.url}
         target="_blank"
@@ -30,7 +31,7 @@ export default function UserMilestone({ milestone, isGoal }) {
             </ReactMarkdown>
           </div>
         </div>
-      </a>
+      </Link>
     </li>
   );
 }

--- a/components/user/UserSocials.js
+++ b/components/user/UserSocials.js
@@ -1,10 +1,11 @@
 import getIcon from "../Icon";
+import Link from "../Link";
 
 function UserSocial({ BASE_URL, username, social }) {
   const DisplayIcon = getIcon(social.icon);
 
   return (
-    <a
+    <Link
       href={`${BASE_URL}/api/users/${username}/links/${encodeURIComponent(
         social.url
       )}`}
@@ -13,7 +14,7 @@ function UserSocial({ BASE_URL, username, social }) {
       className="hover:scale-125 transition ease-in-out delay-100"
     >
       <DisplayIcon aria-label={social.icon.slice(2)} />
-    </a>
+    </Link>
   );
 }
 

--- a/components/user/UserTabs.js
+++ b/components/user/UserTabs.js
@@ -1,4 +1,5 @@
 import { BiSortAlt2 } from "react-icons/bi";
+import Link from "../Link";
 
 export default function UserTabs({ tabs, setTabs, setUserData, userData }) {
   const classNames = (...classes) => classes.filter(Boolean).join(" ");
@@ -103,7 +104,7 @@ export default function UserTabs({ tabs, setTabs, setUserData, userData }) {
         <div className="border-b border-gray-200">
           <nav className="-mb-px flex" aria-label="Tabs">
             {tabs.map((tab) => (
-              <a
+              <Link
                 key={tab.name}
                 href={tab.href}
                 onClick={(e) => changeTab(e, tab.name)}
@@ -142,7 +143,7 @@ export default function UserTabs({ tabs, setTabs, setUserData, userData }) {
                     }}
                   />
                 )}
-              </a>
+              </Link>
             ))}
           </nav>
         </div>

--- a/components/user/UserTestimonials.js
+++ b/components/user/UserTestimonials.js
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import Link from "next/link";
+import Link from "../Link"
 import Alert from "../Alert";
 import FallbackImage from "../FallbackImage";
 import { ReactMarkdown } from "react-markdown/lib/react-markdown";
@@ -30,9 +30,9 @@ export default function UserTestimonials({ data }) {
                 <h3 className="font-medium text-gray-900">
                   {testimonial.title}
                 </h3>
-                <a href={testimonial.url} target="_blank" rel="noreferrer">
+                <Link href={testimonial.url} target="_blank">
                   {testimonial.username}
-                </a>
+                </Link>
               </div>
             </div>
 
@@ -41,9 +41,9 @@ export default function UserTestimonials({ data }) {
                 <h3 className="font-medium text-gray-900">
                   {testimonial.title}
                 </h3>
-                <a href={testimonial.url} target="_blank" rel="noreferrer">
+                <Link href={testimonial.url} target="_blank">
                   {testimonial.username}
-                </a>
+                </Link>
               </div>
               <div className="prose prose-sm max-w-none w-fit text-gray-500">
                 <ReactMarkdown>{testimonial.description}</ReactMarkdown>

--- a/pages/[username].js
+++ b/pages/[username].js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Head from "next/head";
-import Link from "next/link";
+import Link from "../components/Link";
 import { IconContext } from "react-icons";
 import { FaRegComments } from "react-icons/fa";
 import requestIp from "request-ip";

--- a/pages/docs/advanced/single-user-mode.mdx
+++ b/pages/docs/advanced/single-user-mode.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Self hosted single user mode
 
@@ -6,7 +7,7 @@ This allows you to host LinkFree yourself for your single Profile, but this will
 
 ![Self hosted single user mode](https://user-images.githubusercontent.com/624760/212294357-e757236b-9f94-4754-9f1f-a9aae90284e9.png)
 
-1. Add your Profile as normal (see [QuickStart](/docs/quickstart) guide)
+1. Add your Profile as normal (see <Link href="/docs/quickstart">QuickStart</Link> guide)
 2. In the config file `config/user.json` add your username:
 
 ```js

--- a/pages/docs/contributing/automated-tests.mdx
+++ b/pages/docs/contributing/automated-tests.mdx
@@ -1,8 +1,9 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Automated Tests
 
-We use [Playwright](http://playwright.dev) for writing automated end to end (e2e) tests.
+We use <Link href="http://playwright.dev">Playwright</Link> for writing automated end to end (e2e) tests.
 
 1. Install Playwright dependencies `npx playwright install --with-deps`
 1. Run tests `npm run test`

--- a/pages/docs/contributing/storybook.mdx
+++ b/pages/docs/contributing/storybook.mdx
@@ -1,22 +1,23 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Storybook
 
-We use [Storybook](https://storybook.js.org) to display what React components are available to use within our project. This also gives you the opportunity to play with the components' functionality and data it displays.
+We use <Link href="https://storybook.js.org">Storybook</Link> to display what React components are available to use within our project. This also gives you the opportunity to play with the components' functionality and data it displays.
 
 To see what components are available, do the following steps...
 
 1. `npm run storybook`
-1. navigate to http://localhost:6006
+1. navigate to `http://localhost:6006`
 
 _note: not all components have been added, this is a great way to contribute to our project_
 
 ### Updating LinkFree's Storybooks' components
 
 1. Create a story file in `stories/components` with the same filename as the component but append `.stories.js` to the filename
-1. Import the component into the story file, see the existing [example](https://github.com/EddieHubCommunity/LinkFree/blob/main/stories/components/user/UserLink.stories.js)
+1. Import the component into the story file, see the existing <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/stories/components/user/UserLink.stories.js">example</Link>
 1. Set the default arguments by looking at the requirements from the component itself
-1. Run `npm run storybook` to see the added components and visit http://localhost:6006 to interact with them in the browser
+1. Run `npm run storybook` to see the added components and visit `http://localhost:6006` to interact with them in the browser
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree StoryBook Documentation">{children}</DocsLayout>

--- a/pages/docs/environments/github-ui.mdx
+++ b/pages/docs/environments/github-ui.mdx
@@ -1,11 +1,12 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## GitHub UI
 
 Please refer to the following guides that use the GitHub UI to create and edit Profile data
 
-- [QuickStart](/docs/quickstart)
-- [Editing](/docs/how-to-guides/editing)
+- <Link href="/docs/quickstart">QuickStart</Link>
+- <Link href="/docs/how-to-guides/editing">Editing</Link>
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Development in GitHub UI Documentation">

--- a/pages/docs/environments/local-development-docker-compose.mdx
+++ b/pages/docs/environments/local-development-docker-compose.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Local development with Docker Compose
 
@@ -6,7 +7,7 @@ This environment is on your computer but with containers (for example MongoDB) s
 
 ### Prerequisites
 
-You will need [Docker and Docker Compose](https://docs.docker.com/compose/) installed.
+You will need <Link href="https://docs.docker.com/compose/">Docker and Docker Compose</Link> installed.
 
 ### Commands
 

--- a/pages/docs/environments/local-development.mdx
+++ b/pages/docs/environments/local-development.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Quickstart for local development
 
@@ -6,9 +7,10 @@ import DocsLayout from "../../../components/layouts/DocsLayout.js";
 
 Before contributing or adding a new feature, please make sure you have already installed the following tools:
 
-- [NodeJs](https://nodejs.org/en/download/) (Works with Node LTS version v16.17.0)
-- [MongoDB](https://www.mongodb.com/home)
-- Optional [NVM](https://github.com/nvm-sh/nvm): Switch Node version by using `nvm use` (on Windows, use `nvm use v16.17.0`). If this is not installed, run `nvm install v16.17.0`.
+- <Link href="https://nodejs.org/en/download/">NodeJs</Link> (Works with Node LTS
+  version v16.17.0)
+- <Link href="https://www.mongodb.com/home">MongoDB</Link>
+- Optional <Link href="https://github.com/nvm-sh/nvm">NVM</Link>: Switch Node version by using `nvm use` (on Windows, use `nvm use v16.17.0`). If this is not installed, run `nvm install v16.17.0`.
 
 ### Local development
 
@@ -16,8 +18,8 @@ You can set this up locally with the following steps
 
 1. make sure Mongo is running
 1. install npm depenedencies with `npm ci`
-2. a new file will be created `.env` update any details required for example mongo connection string (but usually the default will work fine)
-3. start the app with `npm run dev` and visit in the browser http://localhost:3000
+1. a new file will be created `.env` update any details required for example mongo connection string (but usually the default will work fine)
+1. start the app with `npm run dev` and visit in the browser `http://localhost:3000`
 
 Any changes you make will automatically be reloaded in the browser.
 

--- a/pages/docs/faqs.mdx
+++ b/pages/docs/faqs.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../components/layouts/DocsLayout.js";
+import Link from "../../components/Link";
 
 ## How much does it cost to use
 
@@ -6,13 +7,13 @@ It is completely free to use LinkFree.
 
 ## Is it all Open Source?
 
-Yes, LinkFree is 100% Open Source. You can use our hosted version, or you can self host through [Single user mode](/docs/advanced/single-user-mode).
+Yes, LinkFree is 100% Open Source. You can use our hosted version, or you can self host through <Link href="docs/single-user-mode">Single User Mode</Link>.
 
 We recommend using the hosted version, so that your Profile is more discoverable and you don't have to do the upgrades and updates yourself.
 
 ## Does this count towards Hacktoberfest?
 
-See [Hacktoberfest](/docs/hacktoberfest) page.
+See <Link href="/docs/hacktoberfest">Hacktoberfest</Link> page.
 
 ## My Profile is not showing
 
@@ -20,7 +21,7 @@ Please allow the maintainers time to review and merge your Pull Request, this ca
 
 Once your Pull Request is merged it is deployed automatically. The deployment can take about 5mins after being merged.
 
-If your Profile is not visible after merging, please contact the maintainers in [EddieHub Discord](https://discord.eddiehub.org) or in the [GitHub Discussions in the LinkFree](http://github.com/EddieHubCommunity/LinkFree/discussions) repo.
+If your Profile is not visible after merging, please contact the maintainers in <Link href="https://discord.eddiehub.org">EddieHub Discord</Link> or in the <Link href="http://github.com/EddieHubCommunity/LinkFree/discussions">GitHub Discussions in the LinkFree</Link> repo.
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree FAQ documentation">{children}</DocsLayout>

--- a/pages/docs/full-profile-example.mdx
+++ b/pages/docs/full-profile-example.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../components/layouts/DocsLayout.js";
+import Link from "../../components/Link";
 
 ## Full profile
 
@@ -151,7 +152,7 @@ _Note: the data fields `links`, `milestones`, `testimonials`, `tags`, `socials` 
 }
 ```
 
-Click on the relevant section to learn more about [Events](/docs/how-to-guides/events) and [Testimonials](/docs/how-to-guides/testimonials).
+Click on the relevant section to learn more about <Link href="/docs/how-to-guides/events">Events</Link> and <Link href="/docs/how-to-guides/testimonials">Testimonials</Link>.
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Full Example documentation">

--- a/pages/docs/how-to-guides/bio.mdx
+++ b/pages/docs/how-to-guides/bio.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
-import ClipboardCopy from "../../../components/ClipboardCopy"
+import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Bio
 
@@ -11,7 +12,7 @@ The bio string in the json file is special! It allows for the use of Markdown. T
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. In the `bio` string, you can wrap text in double asterix to make it bold, here is an example
 
@@ -25,7 +26,7 @@ _If you need help on how to edit this file, please see the [Editing guide](/docs
 
 ![LinkFree profile using markdown in bio](https://user-images.githubusercontent.com/624760/208985171-9f337433-92c6-43b7-86a4-05d6af691690.png)
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 _Clicks on these social shortcuts that match any of your links will also increment their respective counters_
 

--- a/pages/docs/how-to-guides/editing.mdx
+++ b/pages/docs/how-to-guides/editing.mdx
@@ -1,4 +1,5 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
 
 ## Edit your profile
 
@@ -68,7 +69,7 @@ You can skip `optional extended message`
 ![pull request](https://user-images.githubusercontent.com/82668196/208293679-822b4d1e-ecc9-49f5-b363-4a0ecf9922f4.png)
 
 16. You will receive a GitHub notification when you have a comment, review or your Pull Request has been merged
-17. Once merged your profile will be available a few minutes later on the same custom url (for example: [linkfree.eddiehub.io/SaraJaoude](https://linkfree.eddiehub.io/SaraJaoude))
+17. Once merged your profile will be available a few minutes later on the same custom url (for example: <Link href="linkfree.eddiehub.io/SaraJaoude">`https://linkfree.eddiehub.io/SaraJaoude`</Link>)
 
 You can learn more about these later on in the documentation, in their respective sections.
 

--- a/pages/docs/how-to-guides/events.mdx
+++ b/pages/docs/how-to-guides/events.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
 import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Events
 
@@ -17,7 +18,7 @@ All future events also appear on the Events page for the app.
 
 2. In your folder add a `json` file with any name you like. We recommend putting the date first and then appending it with the event name. For example `2023-09-13-javascript-conference.json`.
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 3. This `json` file will contain one object for the event and must have six fields, `isVirtual` and/or `isInPerson`, `color`, `name`, `description`, `date` and `url`, which will look like this:
 
@@ -49,7 +50,7 @@ _If you need help on how to edit this file, please see the [Editing guide](/docs
 | cfpClose               | false    | The date of when the CFP to submit a talk closes            |
 | url                    | true     | Where can people learn more about the event                 |
 
-4. Now you can commit your file and create a Pull Request. For more details please see [Editing guide](/docs/how-to-guides/editing)
+4. Now you can commit your file and create a Pull Request. For more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Events Documentation">{children}</DocsLayout>

--- a/pages/docs/how-to-guides/links.mdx
+++ b/pages/docs/how-to-guides/links.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
-import ClipboardCopy from "../../../components/ClipboardCopy"
+import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Links
 
@@ -9,7 +10,7 @@ Let people discover all your great content in one place by adding links to your 
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. Add a collection called `links` at the root of your `json` file which will contain one or more objects that must have three fields `name`, `url` and `icon`.
 
@@ -50,11 +51,10 @@ To add more links add another object inside the links collection. For example:
 ```
 </ClipboardCopy>
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 _Clicks on these social shortcuts that match any of your links will also increment their respective counters_
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Links Documentation">{children}</DocsLayout>
 );
-

--- a/pages/docs/how-to-guides/milestones.mdx
+++ b/pages/docs/how-to-guides/milestones.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
 import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Milestones
 
@@ -11,7 +12,7 @@ Demonstrate the highlights of your career by adding Milestones to your Profile. 
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. Add a collection called `milestones` at the root of your `json` file which will contain one or more social objects. Each social object must have six fields, `title`, `date`, `icon`, `color`, `description` and `url`, which will look like this:
 
@@ -55,7 +56,7 @@ This is what a complete example looks like:
 ```
 </ClipboardCopy>
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Milestones Documentation">{children}</DocsLayout>

--- a/pages/docs/how-to-guides/socials-shortcuts.mdx
+++ b/pages/docs/how-to-guides/socials-shortcuts.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
-import ClipboardCopy from "../../../components/ClipboardCopy"
+import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Social shortcuts
 
@@ -11,7 +12,7 @@ Add a shortcut to your favourite social media accounts at the top of your Profil
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. Add a collection called `socials` at the root of your json file which will contain one or more social objects. Each social object must have two fields, `platform` and `url`, which will look like this:
 
@@ -36,7 +37,7 @@ This is what a complete example looks like:
 ```
 </ClipboardCopy>
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 The icon you would like displayed. We support the following icon sets: **Fa** and **Si** from React Icons.
 

--- a/pages/docs/how-to-guides/statistics.mdx
+++ b/pages/docs/how-to-guides/statistics.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
-import ClipboardCopy from "../../../components/ClipboardCopy"
+import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Statistics
 
@@ -13,7 +14,7 @@ To enable statistics on your Profile, you need to make a change to your `json` f
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. Add another field under your name that is `displayStatsPublic` this will need the value `true` and it should look like this:
 
@@ -29,7 +30,7 @@ _If you need help on how to edit this file, please see the [Editing guide](/docs
 ```
 </ClipboardCopy>
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree Statistics Documentation">{children}</DocsLayout>

--- a/pages/docs/how-to-guides/tags.mdx
+++ b/pages/docs/how-to-guides/tags.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
-import ClipboardCopy from "../../../components/ClipboardCopy"
+import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Tags
 
@@ -11,7 +12,7 @@ These are searchable keywords for people to discover your Profile. They can be y
 
 1. Find your `json` file in the `data` folder using your GitHub username, for example `data/sarajaoude.json`
 
-_If you need help on how to edit this file, please see the [Editing guide](/docs/how-to-guides/editing)_
+_If you need help on how to edit this file, please see the <Link href="/docs/how-to-guides/editing">Editing Guide</Link>_
 
 2. Add a collection called `tags` at the root of your json file which will contain one or more strings.
 
@@ -19,18 +20,14 @@ This is what an example looks like:
 
 <ClipboardCopy>
 ```js
-"tags": [
-  "Open Source",
-  "Javascript",
-  "Typescript",
-  "NextJS",
-  "DevOps",
-  "DevRel"
-]
+{
+  "tags": [ "Open Source", "Javascript", "Typescript", "NextJS", "DevOps",
+  "DevRel" ]
+}
 ```
 </ClipboardCopy>
 
-3. Now you can commit your file and create a Pull Request, for more details please see [Editing guide](/docs/how-to-guides/editing)
+3. Now you can commit your file and create a Pull Request, for more details please see <Link href="/docs/how-to-guides/editing">Editing Guide</Link>
 
 _Clicks on these social shortcuts that match any of your links will also increment their respective counters_
 

--- a/pages/docs/how-to-guides/testimonials.mdx
+++ b/pages/docs/how-to-guides/testimonials.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../../components/layouts/DocsLayout.js";
 import ClipboardCopy from "../../../components/ClipboardCopy";
+import Link from "../../../components/Link";
 
 ## Testimonials
 
@@ -15,7 +16,7 @@ The issue will look like this:
 
 ![LinkFree testimonial issue](https://user-images.githubusercontent.com/624760/210427249-25848dd6-463a-4748-aa60-45c6e53f49a8.png)
 
-**NOTE**: Don't have a LinkFree account but want to give a testimonial? Do not worry! Log in to your GitHub account (if you don't have one, check out [Eddie's course](https://www.eddiejaoude.io/course-github-profile-landing) to help you) and follow the steps above.
+**NOTE**: Don't have a LinkFree account but want to give a testimonial? Do not worry! Log in to your GitHub account (if you don't have one, check out <Link href="https://www.eddiejaoude.io/course-github-profile-landing">Eddie's Course</Link> to help you) and follow the steps above.
 
 ### Manually adding a Testimonial
 

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Page from "../../components/Page";
+import Link from "../../components/Link";
 
 export default function DocsIndex() {
   function classNames(...classes) {
@@ -252,16 +253,9 @@ export default function DocsIndex() {
         <h1 className="text-4xl mb-4 font-bold">Documentation</h1>
         <p>
           Here you should find everything you need from getting started with
-          creating your Profile to more advanced topics. You can contribute to
-          our documentation and find the files here{" "}
-          <a
-            href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs"
-            target="_blank"
-            rel="noreferrer"
-            className="text-sky-700 break-words"
-          >
-            https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs
-          </a>
+          creating your Profile to more advanced topics. We welcome contributions, check out the&nbsp;
+          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree">LinkFree repo</Link> and the&nbsp;
+          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs">documentation source</Link> on GitHub for more information.
         </p>
         {sections.map((section) => (
           <div

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -65,7 +65,8 @@ export default function DocsIndex() {
         {
           name: "Available icons",
           path: "/icons",
-          description: "Search for available icons you can use on your profile.",
+          description:
+            "Search for available icons you can use on your profile.",
           category: {
             name: "Beginner",
             color: "bg-green-100 text-green-800",
@@ -253,9 +254,22 @@ export default function DocsIndex() {
         <h1 className="text-4xl mb-4 font-bold">Documentation</h1>
         <p>
           Here you should find everything you need from getting started with
-          creating your Profile to more advanced topics. We welcome contributions, check out the&nbsp;
-          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree">LinkFree repo</Link> and the&nbsp;
-          <Link target="_blank" href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs">documentation source</Link> on GitHub for more information.
+          creating your Profile to more advanced topics. We welcome
+          contributions, check out the&nbsp;
+          <Link
+            target="_blank"
+            href="https://github.com/EddieHubCommunity/LinkFree"
+          >
+            LinkFree repo
+          </Link>{" "}
+          and the&nbsp;
+          <Link
+            target="_blank"
+            href="https://github.com/EddieHubCommunity/LinkFree/tree/main/pages/docs"
+          >
+            documentation source
+          </Link>{" "}
+          on GitHub for more information.
         </p>
         {sections.map((section) => (
           <div
@@ -284,14 +298,14 @@ export default function DocsIndex() {
                         {page.category.name}
                       </span>
                     </div>
-                    <a href={page.path} className="mt-4 block">
+                    <Link href={page.path} className="mt-4 block">
                       <h3 className="text-xl font-semibold text-gray-900">
                         {page.name}
                       </h3>
                       <p className="mt-3 text-base text-gray-500">
                         {page.description}
                       </p>
-                    </a>
+                    </Link>
                   </div>
                 ))}
               </div>

--- a/pages/docs/quickstart.mdx
+++ b/pages/docs/quickstart.mdx
@@ -1,5 +1,6 @@
 import DocsLayout from "../../components/layouts/DocsLayout.js";
 import ClipboardCopy from "../../components/ClipboardCopy.js";
+import Link from "../../components/Link.js";
 
 ## Quickstart
 
@@ -10,7 +11,7 @@ There are 3 ways you can add your profile, but for this Quickstart we will use t
 To do this, you need a GitHub account. If you do not have one yet, you can create one for free with an email address and password.
 
 1. Log in to your GitHub Account
-2. Visit the [LinkFree repo](https://github.com/EddieHubCommunity/LinkFree)
+2. Visit the <Link href="https://github.com/EddieHubCommunity/LinkFree">LinkFree repo</Link>
 
 ![LinkFree GitHub repo](https://user-images.githubusercontent.com/82668196/208292176-fb2bedf9-8dd1-4fff-b422-30d54f2fdd48.png)
 
@@ -138,7 +139,7 @@ The first dropdown for the `base` repository (destination) should be set to `Edd
 ![pull request](https://user-images.githubusercontent.com/82668196/208292196-c374d328-6bed-4f7b-adbc-b55c29b7c367.png)
 
 18. You will receive a GitHub notification when you have a comment, review or your Pull Request has been merged
-19. Once merged your profile will be available a few minutes later on your custom url (for example: [linkfree.eddiehub.io/SaraJaoude](https://linkfree.eddiehub.io/SaraJaoude))
+19. Once merged your profile will be available a few minutes later on your custom url (<Link href="https://linkfree.eddiehub.io/SaraJaoude">linkfree.eddiehub.io/SaraJaoude</Link>)
 
 ![merged pull request](https://user-images.githubusercontent.com/82668196/208292199-e7a01541-5356-4b2f-8b3e-94be121c661f.png)
 
@@ -146,17 +147,23 @@ The first dropdown for the `base` repository (destination) should be set to `Edd
 
 Looking for inspiration? You can view the following profiles for an example:
 
-- [Eddie Jaoude](https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json)
-- [Krupali Trivedi || Chai](https://github.com/EddieHubCommunity/LinkFree/blob/main/data/krupalitrivedi.json)
-- [Pradumna Saraf](https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json)
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json">
+    Eddie Jaoude
+  </Link>
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/krupalitrivedi.json">
+    Krupali Trivedi || Chai
+  </Link>
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json">
+    Pradumna Saraf
+  </Link>
 
 ### Next steps
 
-- How to [edit and add more](/docs/how-to-guides/editing) to your profile
-- Add [social shortcuts](/docs/how-to-guides/socials-shortcuts) to your profile
-- Add [tags](/docs/how-to-guides/tags) to your profile
-- Add [events](/docs/how-to-guides/events) to your profile
-- Add [testimonials](/docs/how-to-guides/testimonials) to your profile
+- How to <Link href="/docs/how-to-guides/editing">edit and add more</Link> to your profile
+- Add <Link href="/docs/how-to-guides/socials-shortcuts">social shortcuts</Link> to your profile
+- Add <Link href="/docs/how-to-guides/tags">tags</Link> to your profile
+- Add <Link href="/docs/how-to-guides/events">events</Link> to your profile
+- Add <Link href="/docs/how-to-guides/testimonials">testimonials</Link> to your profile
 
 export default ({ children }) => (
   <DocsLayout title="LinkFree QuickStart Documentation">{children}</DocsLayout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import Link from "next/link";
+import Link from "../components/Link";
 import Image from "next/image";
 import { IconContext } from "react-icons";
 import {
@@ -442,7 +442,6 @@ export default function Home({ total, today }) {
         <Link
           href="https://github.com/EddieHubCommunity/LinkFree/discussions"
           rel="noopener noreferrer"
-          target="_blank"
         >
           <div className="fixed bottom-5 right-5 px-4 py-2 bg-indigo-600 text-white flex items-center gap-1 rounded-full hover:drop-shadow-lg">
             <IconContext.Provider


### PR DESCRIPTION
Original PR https://github.com/EddieHubCommunity/LinkFree/pull/3276 by @clintonlunn 

fixes #2523

We can control all links from a custom component

BEFORE

<img width="775" alt="Screenshot 2023-01-23 at 23 47 16" src="https://user-images.githubusercontent.com/624760/214177584-4fe60504-b8cb-4ff4-9abe-94e205ca80be.png">


AFTER

<img width="768" alt="Screenshot 2023-01-23 at 23 47 32" src="https://user-images.githubusercontent.com/624760/214177595-e41eab9c-4940-4f23-ab6f-e394123e4550.png">

