### PR TITLE
Fix Si icons failing accessability test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,6 @@ jobs:
         run: npx playwright install chromium
       - name: run tests
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-      - uses: test-summary/action@v2
+      - uses: test-summary/action@v2.0
         with:
           paths: "results.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - pages/**
       - tests/**
       - components/**
+      - config/**
 
 jobs:
   build:

--- a/components/user/UserLink.js
+++ b/components/user/UserLink.js
@@ -27,7 +27,7 @@ export default function UserLink({
       onClick={() => setClicks(clicks + 1)}
     >
       <span style={{ color: colors[link.icon] }}>
-        <DisplayIcon />
+        <DisplayIcon aria-label={`${link.icon.slice(2)} icon`}/>
       </span>
       <span className="grow">{link.name}</span>
       {displayStatsPublic && <span>{clicks}</span>}


### PR DESCRIPTION
Changes made to the `config/icons.json` caused Si icons to be added to our profile test.
The SI icons are generated in a different way to Fa icons which causes accessibility issues.
This PR fixes the test and adds the config directory to the list of changes to run tests.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

