### PR TITLE
Fix: Stats text underflow

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -128,8 +128,7 @@ export default function Home({ total, today }) {
         "Make it easier to share your Profile when you meet people with your unique QR code.",
       imageSrc:
         "https://user-images.githubusercontent.com/100528412/211307797-e7ae2d78-f7e2-48c5-a4d2-910bcb69a8e5.png",
-      imageAlt:
-        "LinkFree screenshot of a QR code example",
+      imageAlt: "LinkFree screenshot of a QR code example",
     },
     {
       name: "Your Links",
@@ -137,8 +136,7 @@ export default function Home({ total, today }) {
         "Let people discover all your great content in one place by adding links to your different socials, website, blog ... and more.",
       imageSrc:
         "https://user-images.githubusercontent.com/624760/210063791-91499fe2-3f30-4333-9623-78d5075a3d79.png",
-      imageAlt:
-        "LinkFree screenshot of links section of an example profile",
+      imageAlt: "LinkFree screenshot of links section of an example profile",
     },
     {
       name: "Your Milestones",
@@ -163,8 +161,7 @@ export default function Home({ total, today }) {
         "Hosting or attending events, let people know what you are up to.",
       imageSrc:
         "https://user-images.githubusercontent.com/624760/210063782-3e6ed687-7d1b-4a23-bd02-aa88968ad0ec.png",
-      imageAlt:
-        "LinkFree screenshot of events section of an example profile",
+      imageAlt: "LinkFree screenshot of events section of an example profile",
     },
     {
       name: "Community Events",
@@ -196,7 +193,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Active Users
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between md:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.active)}
                     <span className="ml-2 text-sm font-medium text-gray-500">
@@ -205,7 +202,7 @@ export default function Home({ total, today }) {
                       </span>
                     </span>
                   </div>
-                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium md:mt-2 lg:mt-0">
+                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium sm:mt-2 lg:mt-0">
                     <MdArrowUpward
                       className="-ml-1 mr-0.5 h-5 w-5 flex-shrink-0 self-center text-green-500"
                       aria-hidden="true"
@@ -222,7 +219,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Profile views
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between md:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.views)}
                     <span className="ml-2 text-sm font-medium text-gray-500">
@@ -230,7 +227,7 @@ export default function Home({ total, today }) {
                     </span>
                   </div>
 
-                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium md:mt-2 lg:mt-0">
+                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium sm:mt-2 lg:mt-0">
                     <MdArrowUpward
                       className="-ml-1 mr-0.5 h-5 w-5 flex-shrink-0 self-center text-green-500"
                       aria-hidden="true"
@@ -247,7 +244,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Links clicked
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between md:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.clicks)}
                     <span className="ml-2 text-sm font-medium text-gray-500">
@@ -255,7 +252,7 @@ export default function Home({ total, today }) {
                     </span>
                   </div>
 
-                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium md:mt-2 lg:mt-0">
+                  <div className="bg-green-100 text-green-800 inline-flex items-baseline px-2.5 py-0.5 rounded-full text-sm font-medium sm:mt-2 lg:mt-0">
                     <MdArrowUpward
                       className="-ml-1 mr-0.5 h-5 w-5 flex-shrink-0 self-center text-green-500"
                       aria-hidden="true"
@@ -402,7 +399,8 @@ export default function Home({ total, today }) {
               <div className="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-3">
                 {features.map((feature) => (
                   <div key={feature.name} className="pt-6">
-                    <Link aria-label="Go to ${feature.name} page"
+                    <Link
+                      aria-label="Go to ${feature.name} page"
                       href={feature.path}
                       className="text-gray-900 group"
                     >

--- a/pages/index.js
+++ b/pages/index.js
@@ -193,7 +193,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Active Users
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block min-[868px]:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.active)}
                     <span className="ml-2 text-sm font-medium text-gray-500">
@@ -219,7 +219,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Profile views
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block min-[868px]:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.views)}
                     <span className="ml-2 text-sm font-medium text-gray-500">
@@ -244,7 +244,7 @@ export default function Home({ total, today }) {
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Links clicked
                 </dt>
-                <dd className="mt-1 flex items-baseline justify-between sm:block lg:flex">
+                <dd className="mt-1 flex items-baseline justify-between sm:block min-[868px]:flex">
                   <div className="flex items-baseline text-2xl font-semibold text-indigo-600">
                     {abbreviateNumber(total.clicks)}
                     <span className="ml-2 text-sm font-medium text-gray-500">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Fix: #4301 - Stats text overflow on mobile to desktop transition 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

![Untitled](https://user-images.githubusercontent.com/94737463/215752070-b1f8e850-3cac-4b53-8340-8fa36797f2b9.png)

Here is the live preview of the output:

https://user-images.githubusercontent.com/94737463/215751866-b7810bee-482c-4a5c-9c9a-fd003f5f6f05.mp4



## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

