### PR TITLE
feat: add @ sign for usernames in testimonials

### DIFF
--- a/components/user/UserTestimonials.js
+++ b/components/user/UserTestimonials.js
@@ -31,7 +31,7 @@ export default function UserTestimonials({ data }) {
                   {testimonial.title}
                 </h3>
                 <Link href={testimonial.url} target="_blank">
-                  {testimonial.username}
+                  @{testimonial.username}
                 </Link>
               </div>
             </div>
@@ -42,7 +42,7 @@ export default function UserTestimonials({ data }) {
                   {testimonial.title}
                 </h3>
                 <Link href={testimonial.url} target="_blank">
-                  {testimonial.username}
+                  @{testimonial.username}
                 </Link>
               </div>
               <div className="prose prose-sm max-w-none w-fit text-gray-500">


### PR DESCRIPTION
Due we display usernames in the testimonials I would mark them with an @ sign at the beginning.

![image](https://user-images.githubusercontent.com/30869493/216272266-7a6f1273-6626-470c-b428-43bf34e334d6.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

