### PR TITLE
Fixed #4506

### DIFF
--- a/components/layouts/DocsLayout.js
+++ b/components/layouts/DocsLayout.js
@@ -32,7 +32,7 @@ export default function DocsLayout({ children, title }) {
           >
             documentation source
           </Link>{" "}
-          and the&nbsp; on GitHub for more information.
+          on GitHub for more information.
         </p>
         <div className="float-none my-0 max-w-[1440px] prose">
           <div className="flex flex-grow flex-row">


### PR DESCRIPTION
Removed the extra words on DocsLayout.js. Fixed #4506


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

