### PR TITLE
Add robots.txt for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# allow all crawlers
+user-agent: *
+allow: /


### PR DESCRIPTION
## Changes proposed
Currently when a crawler requests `robots.txt`, LinkFree returns the search page using `robots.txt` as the search term.
This PR adds a `robots.txt` to public allowing all crawlers

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
