### PR TITLE
Fix storybook warning & deploy on dispatch

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm run build-storybook
 
       - name: Upload artifact
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v1
         with:
           path: './storybook-static'
@@ -53,7 +53,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   stories: [
     "../stories/**/*.stories.mdx",
     "../stories/**/*.stories.@(js|jsx|ts|tsx)",
@@ -18,3 +18,5 @@ module.exports = {
     STORYBOOK_RUN: true,
   }),
 };
+
+export default config


### PR DESCRIPTION
## Changes proposed
Fix storybook warning for `.storybook/main.js`
Deploy storybook on workflow_dispatch


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4592"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

