### PR TITLE
fixes sticking of login button to github link icons in small width screens

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -187,7 +187,7 @@ export default function Navbar() {
             <div className="flex items-center px-5">
               <div className="flex items-center md:ml-6">
                 <span className="text-gray-400">v{app.version}</span>
-                <div className="ml-3 relative">
+                <div className="mx-3 relative">
                   <Link
                     href="https://github.com/EddieHubCommunity/LinkFree"
                     aria-current="page"


### PR DESCRIPTION
Fixes issue : https://github.com/EddieHubCommunity/LinkFree/issues/4514
This is happens on smaller machines that the login button gets too close(has on margin-left) to the the GitHub icons which looks weird on hovering, 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4612"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

