### PR TITLE
Pin changed-files action to working version

### DIFF
--- a/.github/workflows/data-filenames.yml
+++ b/.github/workflows/data-filenames.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v35.5.0
 
       - name: Get changed files between base & head
         id: base-changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v35.5.0
         with:
           base_sha: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
## Changes proposed
Changes released by [tj-actions/changed-files](https://github.com/tj-actions/changed-files) have caused the data-filenames action to be erratic.
This PR pins the version to the latest one known to work while the changes are investigated.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4615"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

