### PR TITLE
Ignore remote as a location

### DIFF
--- a/pages/map.js
+++ b/pages/map.js
@@ -17,7 +17,9 @@ export async function getServerSideProps() {
   users = users.filter(
     (user) =>
       user.location &&
-      (user.location.provided !== "unknown" || user.location.name !== "unknown")
+      (user.location.provided !== "unknown" ||
+        user.location.name !== "unknown" ||
+        user.location.name.toLowerCase() === "remote")
   );
 
   return {

--- a/services/github/getLocationByUsername.js
+++ b/services/github/getLocationByUsername.js
@@ -20,7 +20,7 @@ export default async function getLocationByUsername(username) {
     return location;
   }
 
-  if (!github.data.location) {
+  if (!github.data.location || github.data.location.toLowerCase() === 'remote') {
     return location;
   }
 


### PR DESCRIPTION
## Changes proposed
Remote is a valid location in Oregon .
This is not likely the location of people who set their location on GitHub to Remote.
This PR will ignore the location.