### PR TITLE
Fix typo in statistics.js

### DIFF
--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -98,7 +98,7 @@ export default function Search({ data, profile }) {
         </h1>
 
         {!data.links && (
-          <Alert type="info" message="You don't have a proile yet." />
+          <Alert type="info" message="You don't have a profile yet." />
         )}
 
         <div className="border mb-6">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #4708 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

There is a typo on line 101 in the Alert message of the [pages/account/statistics.js](https://github.com/EddieHubCommunity/LinkFree/blob/main/pages/account/statistics.js#L101) file. 

The word `proile` was changed to `profile`

### Before
![Screenshot from 2023-02-11 21-47-21](https://user-images.githubusercontent.com/70024383/218291695-c035358a-8595-490e-ac85-dbd90443ffdd.png)



### After
![Screenshot from 2023-02-12 09-07-23](https://user-images.githubusercontent.com/70024383/218291670-0098f5a0-0815-4ca5-be12-423a3433f5ce.png)


<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4724"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

