### PR TITLE
Fix: display copy alert over Navbar

### DIFF
--- a/components/IconCard.js
+++ b/components/IconCard.js
@@ -24,7 +24,7 @@ export default function IconCard({ iconName }) {
       </button>
       <div
         aria-live="assertive"
-        className="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
+        className="pointer-events-none fixed z-40 inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
       >
         <div className="flex w-full flex-col items-center space-y-4 sm:items-end">
           <Transition

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -88,7 +88,7 @@ export default function Navbar() {
   return (
     <div className="min-h-full" ref={navConRef}>
       <nav className=" relative top-0">
-        <div className=" z-30 bg-gray-800 w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
+        <div className="z-30 bg-gray-800 w-full mx-auto px-4 sm:px-6 lg:px-8 relative t-0">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">
@@ -172,11 +172,10 @@ export default function Navbar() {
         </div>
 
         <div
-          className={`${
-            isOpen
+          className={`${isOpen
               ? "transform translate-y-0 opacity-100"
               : "transform -translate-y-96 opacity-0 "
-          } md:hidden z-20 absolute t-0 bg-gray-800 transition-all duration-700 ease-in-out  w-full`}
+            } md:hidden z-20 absolute t-0 bg-gray-800 transition-all duration-700 ease-in-out  w-full`}
           id="mobile-menu"
         >
           <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fix Issue

fixes #4729

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed: set zindex of copy alert more than the navbar so it displays over it.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![linkfree copyalert](https://user-images.githubusercontent.com/100035026/218389602-b8d75e35-f2bc-4ea5-9f8a-814034f7dcc6.png)


<!-- Add all the screenshots which support your changes -->

## Note to reviewers:

I know it covers the version and login area of the navbar when clicked on any icon, but it's an alert which closes after 1.5 seconds, 
and as my understanding the alert component's position was already there, some recent changes in the code may have set the z-index of navbar 30 to solve another issue, which caused this issue. I could have changed the copy alerts position to the same as in mobile view, but I decided to keep it at its old position and just increase its priority to display.

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4775"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

