### PR TITLE
Accessibility: Remove bounce effect on QR codes

### DIFF
--- a/components/Badge.js
+++ b/components/Badge.js
@@ -36,7 +36,7 @@ export default function Badge({
   const badge = (
     <div
       title={title}
-      className={`absolute inline-block translate-x-2/4 -translate-y-1/2 rotate-0 skew-x-0 skew-y-0 scale-x-100 scale-y-100 py-1 px-1.5 text-xs leading-none text-center whitespace-nowrap align-baseline font-bold bg-orange-600 text-black rounded-full z-10 ${css} ${badgeClassName}`}
+      className={`absolute inline-block rotate-0 skew-x-0 skew-y-0 scale-x-100 scale-y-100 py-1 px-1.5 text-xs leading-none text-center whitespace-nowrap align-baseline font-bold bg-orange-600 text-black rounded-full z-10 ${css} ${badgeClassName}`}
       onClick={() => (onClick ? onClick() : null)}
     >
       {content}

--- a/components/Tag.js
+++ b/components/Tag.js
@@ -3,7 +3,7 @@ import Badge from "./Badge";
 
 export default function Tag({ name, total, selected, onClick }) {
   return (
-    <Badge content={abbreviateNumber(total)} display={!!total}>
+    <Badge content={abbreviateNumber(total)} display={!!total} badgeClassName={"translate-x-2/4 -translate-y-1/2"}>
       <div
         onClick={onClick}
         className={`flex flex-row p-1 m-2 rounded-lg text-sm font-mono border-2 cursor-pointer shadow-none ${

--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -18,7 +18,7 @@ export default function UserProfile({ BASE_URL, data }) {
         <Badge
           content={<MdQrCode2 size="2em" />}
           position="bottom-left"
-          badgeClassName="animate-bounce cursor-pointer"
+          badgeClassName="cursor-pointer"
           onClick={() => (qrShow ? setQrShow(false) : setQrShow(true))}
         >
           <FallbackImage

--- a/pages/events.js
+++ b/pages/events.js
@@ -78,6 +78,7 @@ export default function Events({ events }) {
             content="?"
             path="/docs/how-to-guides/events"
             title="Go To Event Docs"
+            badgeClassName={"translate-x-2/4 -translate-y-1/2"}
           >
             <h1 className="text-4xl mb-4 font-bold ">Community events</h1>
           </Badge>

--- a/pages/search.js
+++ b/pages/search.js
@@ -142,6 +142,7 @@ export default function Search({ data }) {
           content={filteredUsers.length}
           display={!!filteredUsers}
           className="w-full"
+          badgeClassName={"translate-x-2/4 -translate-y-1/2"}
         >
           <input
             placeholder="Search user by name or tags; eg: open source,reactjs"


### PR DESCRIPTION
## Closes #4792

This change updates the Profile page so that the QR code no longer has a bouncing effect, which can be distracting for certain individuals.

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

<details>
  <summary>Video description</summary>
  <div>The video shows a LinkFree Profile page showing the QR code no longer having a bounce effect. Clicking the QR code expands the QR code.</div>

</details>

[](https://user-images.githubusercontent.com/478770/218995971-eaa26730-6eb1-4457-b104-77f51d3feeba.mov)

## Note to reviewers

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/4835"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

