### PR TITLE
Use Image Priority on above the fold images for profile pages

### DIFF
--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -98,6 +98,7 @@ export default function Navbar() {
                     alt="EddieHub logo"
                     width={32}
                     height={32}
+                    priority
                     onClick={() => setIsOpen(false)}
                   />
                 </Link>

--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -27,6 +27,7 @@ export default function UserProfile({ BASE_URL, data }) {
             width={fallbackImageSize}
             height={fallbackImageSize}
             fallback={data.name}
+            priority
             className="rounded-full object-contain"
           />
         </Badge>


### PR DESCRIPTION
## Changes proposed
Add the priority option on the image component for:
1. NavBar image
2. Profile picture

This will start fetching the images earlier in the process of loading the page.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

