### PR TITLE
roll back logger change for CopyClipboard

### DIFF
--- a/components/ClipboardCopy.js
+++ b/components/ClipboardCopy.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { onlyText } from "react-children-utilities";
-import logger from "../config/logger";
 
 const ClipboardCopy = ({ children }) => {
   const [isCopied, setIsCopied] = useState(false);
@@ -21,7 +20,7 @@ const ClipboardCopy = ({ children }) => {
         setIsCopied(false);
       }, 1500);
     } catch (error) {
-      logger.error(error);
+      console.error(error);
     }
   };
 


### PR DESCRIPTION
## Fixes Issue
Closes #4903 
This rolls back the logger change from #4837 as the logger is incompatible with webpack

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
