### PR TITLE
fix: upgarde LinkFree-CLI version to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint-config-next": "^13.1.6",
         "eslint-plugin-storybook": "^0.6.10",
         "husky": "^8.0.3",
-        "linkfree-cli": "^1.4.1",
+        "linkfree-cli": "^2.0.0",
         "lint-staged": "^13.1.0",
         "ncp": "^2.0.0",
         "postcss": "^8.4.21",
@@ -4055,6 +4055,21 @@
       "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
       "cpu": [
         "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
+      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "cpu": [
+        "arm64"
       ],
       "optional": true,
       "os": [
@@ -14536,15 +14551,16 @@
       "dev": true
     },
     "node_modules/linkfree-cli": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-1.4.1.tgz",
-      "integrity": "sha512-qy9lflpytln4oZXOOs2Zb1vVU+FmGse1ITy4TFMT9E7vG8CxfekO5La5r7XQuamVf7/u0Fn5gICoI5BWzo85rw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.0.tgz",
+      "integrity": "sha512-i+9rkz649zMjr8grJ5wMd17/7vc1o1sI8Xw+WPvEvBO9316q1pinCpnBc4761uia4GeNKez7Z3fW5ZsyVqmivA==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
         "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
-        "json-format": "^1.0.1"
+        "json-format": "^1.0.1",
+        "open": "^8.4.2"
       },
       "bin": {
         "linkfree-cli": "src/index.js"
@@ -16860,9 +16876,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.1.tgz",
-      "integrity": "sha512-/4b7qZNhv6Uhd7jjnREh1NjnPxlTq+XNWPG88Ydkj5AILcA5m3ajvcg57pB24EQjKv0dK62XnDqk9c/hkIG5Kg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -21784,21 +21800,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
-      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   },
   "dependencies": {
@@ -24681,6 +24682,12 @@
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
       "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
+      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
@@ -32464,15 +32471,16 @@
       "dev": true
     },
     "linkfree-cli": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-1.4.1.tgz",
-      "integrity": "sha512-qy9lflpytln4oZXOOs2Zb1vVU+FmGse1ITy4TFMT9E7vG8CxfekO5La5r7XQuamVf7/u0Fn5gICoI5BWzo85rw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.0.tgz",
+      "integrity": "sha512-i+9rkz649zMjr8grJ5wMd17/7vc1o1sI8Xw+WPvEvBO9316q1pinCpnBc4761uia4GeNKez7Z3fW5ZsyVqmivA==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",
         "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
-        "json-format": "^1.0.1"
+        "json-format": "^1.0.1",
+        "open": "^8.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -34067,9 +34075,9 @@
       }
     },
     "open": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.1.tgz",
-      "integrity": "sha512-/4b7qZNhv6Uhd7jjnREh1NjnPxlTq+XNWPG88Ydkj5AILcA5m3ajvcg57pB24EQjKv0dK62XnDqk9c/hkIG5Kg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
@@ -37691,12 +37699,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
-    },
-    "@next/swc-android-arm64": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
-      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
-      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "postinstall": "ncp ./.env.example ./.env",
-    "create": "npx linkfree-cli"
+    "cli": "npx linkfree-cli"
   },
   "browserslist": {
     "production": [
@@ -82,7 +82,7 @@
     "eslint-config-next": "^13.1.6",
     "eslint-plugin-storybook": "^0.6.10",
     "husky": "^8.0.3",
-    "linkfree-cli": "^1.4.1",
+    "linkfree-cli": "^2.0.0",
     "lint-staged": "^13.1.0",
     "ncp": "^2.0.0",
     "postcss": "^8.4.21",


### PR DESCRIPTION
- Update the **LinkFree-CLI** to `v2.0.0` after new relaese.

Now we can 
- Creating a LinkFree profile.
- Updating a LinkFree profile.
- Giving a testimonial to a LinkFree profile.
- Adding events (conferences, meetups, etc).

And change the script to `cli: npx linkfree-cli`

```
npm run cli
```

Repo - https://github.com/Pradumnasaraf/LinkFree-CLI
NPM - https://www.npmjs.com/package/linkfree-cli