### PR TITLE
docs: Add docs for LinkFree CLI

### DIFF
--- a/pages/docs/environments/linkfree-cli.mdx
+++ b/pages/docs/environments/linkfree-cli.mdx
@@ -1,0 +1,43 @@
+import DocsLayout from "../../../components/layouts/DocsLayout.js";
+import Link from "../../../components/Link";
+
+## Quick demo 
+
+![LinkFree CLI demo](https://user-images.githubusercontent.com/51878265/220884496-3025e260-bcfe-4abe-b639-b66592dd4038.gif)
+
+
+## What is LinkFree CLI?
+
+**LinkFree CLI** is a command line tool that helps us create and update a JSON file for your LinkFree profile. We can also give testimonal to other LinkFree profiles and add events.
+
+## Installation and using the CLI
+
+1. Make sure you have cloned the [LinkFree](https://github.com/EddieHubCommunity/LinkFree) repository and have installed the dependencies. Also make sure you are in the root directory of the project.
+
+2. To trigger the CLI, run the following command.
+
+```bash
+npm run cli
+```
+
+- We you run the above command it will run `npx linkfree-cli`. We use **npx** to run the CLI without installing it globally.
+
+3. Then you will then promted with several options. You can use the arrow keys to navigate and press enter to select the task you want to perform and then you will be prompted with the questions.
+
+![LinkFree CLI main prompt](https://user-images.githubusercontent.com/51878265/220891756-10861090-e719-4687-b4fb-f7bef2826934.png)
+
+4. Once you are done with the questions, it will create the JSON file depending on the task you selected. For example, if you selected `Create a LinkFree JSON file`, it will create a JSON file in the `public/data` directory. You will also get a message in the terminal. Something simlar to the following image.
+
+![LinkFree CLI JSON file created](https://user-images.githubusercontent.com/51878265/220895327-ebb3a616-eedf-4497-9663-081064168d93.png)
+
+5. Once the JSON file is created by the CLI, you can commit the changes and create a pull request.
+
+## Feedback
+
+If you find any kid of bug you can use the 5th option `🐛 Report a bug` in main prompt to report the bug. You can also create an issue in the [LinkFree CLI](https://github.com/Pradumnasaraf/LinkFree-CLI/issues/new?assignees=&labels=bug&template=bug.yaml) repository.
+
+export default ({ children }) => (
+  <DocsLayout title="Creating profile via LinkFree CLI">
+    {children}
+  </DocsLayout>
+);

--- a/pages/docs/environments/linkfree-cli.mdx
+++ b/pages/docs/environments/linkfree-cli.mdx
@@ -8,7 +8,7 @@ import Link from "../../../components/Link";
 
 ## What is LinkFree CLI?
 
-**LinkFree CLI** is a command line tool that helps us create a JSON and update anexisting JSON file for your LinkFree profile. We can also give testimonials to other LinkFree profiles and add events.
+**LinkFree CLI** is a command line tool that helps us create a JSON and update an existing JSON file for your LinkFree profile. We can also give testimonials to other LinkFree profiles and add events.
 
 ## Installation and using the CLI
 

--- a/pages/docs/environments/linkfree-cli.mdx
+++ b/pages/docs/environments/linkfree-cli.mdx
@@ -8,11 +8,11 @@ import Link from "../../../components/Link";
 
 ## What is LinkFree CLI?
 
-**LinkFree CLI** is a command line tool that helps us create and update a JSON file for your LinkFree profile. We can also give testimonal to other LinkFree profiles and add events.
+**LinkFree CLI** is a command line tool that helps us create a JSON and update anexisting JSON file for your LinkFree profile. We can also give testimonials to other LinkFree profiles and add events.
 
 ## Installation and using the CLI
 
-1. Make sure you have cloned the [LinkFree](https://github.com/EddieHubCommunity/LinkFree) repository and have installed the dependencies. Also make sure you are in the root directory of the project.
+1. Make sure you have cloned the [LinkFree](https://github.com/EddieHubCommunity/LinkFree) repository and have installed the dependencies. Also, make sure you are in the root directory of the project.
 
 2. To trigger the CLI, run the following command.
 
@@ -20,13 +20,13 @@ import Link from "../../../components/Link";
 npm run cli
 ```
 
-- We you run the above command it will run `npx linkfree-cli`. We use **npx** to run the CLI without installing it globally.
+- When we run the above command it will run `npx linkfree-cli`. We use **npx** to run the CLI without installing it globally.
 
-3. Then you will then promted with several options. You can use the arrow keys to navigate and press enter to select the task you want to perform and then you will be prompted with the questions.
+3. Then you will then prompted with several options. You can use the arrow keys to navigate and press enter to select the task you want to perform and then you will be prompted with the questions.
 
 ![LinkFree CLI main prompt](https://user-images.githubusercontent.com/51878265/220891756-10861090-e719-4687-b4fb-f7bef2826934.png)
 
-4. Once you are done with the questions, it will create the JSON file depending on the task you selected. For example, if you selected `Create a LinkFree JSON file`, it will create a JSON file in the `public/data` directory. You will also get a message in the terminal. Something simlar to the following image.
+4. Once you are done with the questions, it will create the JSON file depending on the task you selected. For example, if you selected `Create a LinkFree JSON file`, it will create a JSON file in the `public/data` directory. You will also get a message in the terminal. Something similar to the following image.
 
 ![LinkFree CLI JSON file created](https://user-images.githubusercontent.com/51878265/220895327-ebb3a616-eedf-4497-9663-081064168d93.png)
 
@@ -34,7 +34,7 @@ npm run cli
 
 ## Feedback
 
-If you find any kid of bug you can use the 5th option `🐛 Report a bug` in main prompt to report the bug. You can also create an issue in the [LinkFree CLI](https://github.com/Pradumnasaraf/LinkFree-CLI/issues/new?assignees=&labels=bug&template=bug.yaml) repository.
+If you find any kind of bug you can use the 5th option `🐛 Report a bug` in the main prompt to report the bug. You can also create an issue in the [LinkFree CLI](https://github.com/Pradumnasaraf/LinkFree-CLI/issues/new?assignees=&labels=bug&template=bug.yaml) repository.
 
 export default ({ children }) => (
   <DocsLayout title="Creating profile via LinkFree CLI">

--- a/pages/docs/environments/linkfree-cli.mdx
+++ b/pages/docs/environments/linkfree-cli.mdx
@@ -26,7 +26,7 @@ npm run cli
 
 ![LinkFree CLI main prompt](https://user-images.githubusercontent.com/51878265/220891756-10861090-e719-4687-b4fb-f7bef2826934.png)
 
-4. Once you are done with the questions, it will create the JSON file depending on the task you selected. For example, if you selected `Create a LinkFree JSON file`, it will create a JSON file in the `public/data` directory. You will also get a message in the terminal. Something similar to the following image.
+4. Once you are done with the questions, it will create the JSON file depending on the task you selected. For example, if you selected `Create a LinkFree JSON file`, it will create a JSON file in the `data/` directory. You will also get a message in the terminal. Something similar to the following image.
 
 ![LinkFree CLI JSON file created](https://user-images.githubusercontent.com/51878265/220895327-ebb3a616-eedf-4497-9663-081064168d93.png)
 

--- a/pages/docs/environments/linkfree-cli.mdx
+++ b/pages/docs/environments/linkfree-cli.mdx
@@ -22,7 +22,7 @@ npm run cli
 
 - When we run the above command it will run `npx linkfree-cli`. We use **npx** to run the CLI without installing it globally.
 
-3. Then you will then prompted with several options. You can use the arrow keys to navigate and press enter to select the task you want to perform and then you will be prompted with the questions.
+3. You will then be prompted with several options. You can use the arrow keys to navigate and press enter to select the task you want to perform and then you will be prompted with the questions.
 
 ![LinkFree CLI main prompt](https://user-images.githubusercontent.com/51878265/220891756-10861090-e719-4687-b4fb-f7bef2826934.png)
 

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -63,6 +63,16 @@ export default function DocsIndex() {
           },
         },
         {
+          name: "LinkFree CLI",
+          path: "/docs/environments/linkfree-cli",
+          description:
+            "This CLI tool will allow you to create profile, update profile, add testimonal and more from the command line.",
+          category: {
+            name: "Intermediate",
+            color: "bg-orange-100 text-orange-800",
+          },
+        },
+        {
           name: "Available icons",
           path: "/icons",
           description:


### PR DESCRIPTION
## Changes proposed

- Add a section in docs for LinkFree CLI.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.

## Screenshots

### Docs homepage

<img width="1471" alt="Screenshot 2023-02-23 at 5 18 16 PM" src="https://user-images.githubusercontent.com/51878265/220898053-c1ffaefd-465d-4a65-bc85-b385883a708e.png">

### CLI docs

https://user-images.githubusercontent.com/51878265/220897863-3bdc4057-1d19-48db-be5c-ca2c0c65b185.mov







<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5027"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

