### PR TITLE
chore: fix LinkFree CLI version to `v2.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint-config-next": "^13.1.6",
         "eslint-plugin-storybook": "^0.6.10",
         "husky": "^8.0.3",
-        "linkfree-cli": "^2.0.0",
+        "linkfree-cli": "^2.0.1",
         "lint-staged": "^13.1.0",
         "ncp": "^2.0.0",
         "postcss": "^8.4.21",
@@ -14551,9 +14551,9 @@
       "dev": true
     },
     "node_modules/linkfree-cli": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.0.tgz",
-      "integrity": "sha512-i+9rkz649zMjr8grJ5wMd17/7vc1o1sI8Xw+WPvEvBO9316q1pinCpnBc4761uia4GeNKez7Z3fW5ZsyVqmivA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.1.tgz",
+      "integrity": "sha512-xwEUhIoI5ZVojxn75hA6jC7CL/TQeAAaq4e0XRwHjCRm8reAKHVSZMXkjlZC6WrMmuUdnxtvIa3AA+4D0mhAgQ==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
@@ -32471,9 +32471,9 @@
       "dev": true
     },
     "linkfree-cli": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.0.tgz",
-      "integrity": "sha512-i+9rkz649zMjr8grJ5wMd17/7vc1o1sI8Xw+WPvEvBO9316q1pinCpnBc4761uia4GeNKez7Z3fW5ZsyVqmivA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.1.tgz",
+      "integrity": "sha512-xwEUhIoI5ZVojxn75hA6jC7CL/TQeAAaq4e0XRwHjCRm8reAKHVSZMXkjlZC6WrMmuUdnxtvIa3AA+4D0mhAgQ==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-config-next": "^13.1.6",
     "eslint-plugin-storybook": "^0.6.10",
     "husky": "^8.0.3",
-    "linkfree-cli": "^2.0.0",
+    "linkfree-cli": "^2.0.1",
     "lint-staged": "^13.1.0",
     "ncp": "^2.0.0",
     "postcss": "^8.4.21",


### PR DESCRIPTION
- Fix version to `v2.0.1` there was an accessibility issue in `v2.0.0`

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5033"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

