### PR TITLE
fix: NavLink active state not persist

### DIFF
--- a/components/navbar/NavLink.js
+++ b/components/navbar/NavLink.js
@@ -9,7 +9,7 @@ export default function NavLink({ path, item, mode, setIsOpen, onClick }) {
       "text-gray-300 hover:ring-2 hover:ring-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium";
   }
 
-  if (path?.split("/")[1] === item.url.replace("/", "")) {
+  if (path?.split("/")[1] === item.url.split("/")[1]) {
     if (mode === "mobile") {
       className =
         "bg-gray-900 text-white block px-3 py-2 rounded-md text-base font-medium";

--- a/components/navbar/NavLink.js
+++ b/components/navbar/NavLink.js
@@ -9,7 +9,7 @@ export default function NavLink({ path, item, mode, setIsOpen, onClick }) {
       "text-gray-300 hover:ring-2 hover:ring-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium";
   }
 
-  if (path === item.url) {
+  if (path?.split("/")[1] === item.url.replace("/", "")) {
     if (mode === "mobile") {
       className =
         "bg-gray-900 text-white block px-3 py-2 rounded-md text-base font-medium";

--- a/components/navbar/Navbar.js
+++ b/components/navbar/Navbar.js
@@ -106,7 +106,7 @@ export default function Navbar() {
               <div className="hidden md:block">
                 <div className="ml-10 flex items-baseline space-x-4">
                   {primary.map((item) => (
-                    <NavLink key={item.name} path={router.asPath} item={item} />
+                    <NavLink key={item.name} path={router.pathname} item={item} />
                   ))}
                 </div>
               </div>
@@ -185,7 +185,7 @@ export default function Navbar() {
             {primary.map((item, index) => (
               <NavLink
                 key={index}
-                path={router.asPath}
+                path={router.pathname}
                 item={item}
                 mode="mobile"
                 setIsOpen={setIsOpen}


### PR DESCRIPTION
## Fixes Issue

fixes #5190 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

The proposed change replaces a direct string comparison between the `path` and `item` variables with a more flexible check that extracts a specific substring from the path and compares it to a modified version of the `url` property of the item object. This change allows for more robust matching of URLs with different structures, while still achieving the same functional outcome.


<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Video Preview

Here is the video of the resulted behavior:

- For desktop screen:


https://user-images.githubusercontent.com/94737463/222326307-e8cb0aa5-4d42-46e1-819d-147a73c53bc4.mp4


- For mobile screen:


https://user-images.githubusercontent.com/94737463/222326364-0464f1d6-8550-450c-98a8-9551eddfe317.mp4

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5197"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

