### PR TITLE
Changed my "Socials" to "links"

### DIFF
--- a/data/VarchasvH.json
+++ b/data/VarchasvH.json
@@ -11,7 +11,7 @@
     "CI/CD",
     "Golang"
   ],
-  "Socials": [
+  "links": [
     {
       "name": "Follow me on Twitter",
       "url": "https://twitter.com/VarchasvH/",


### PR DESCRIPTION
I was having an Internal error 500, when I was trying to access my LinkFree page. One suggestion that I found was to change my "Socials" to "links". Refer to this [Q&A](https://github.com/EddieHubCommunity/LinkFree/discussions/5068)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

