### PR TITLE
fix: bump LinkFree-CLI version to v2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "eslint-config-next": "^13.1.6",
         "eslint-plugin-storybook": "^0.6.10",
         "husky": "^8.0.3",
-        "linkfree-cli": "^2.0.1",
+        "linkfree-cli": "^2.2.2",
         "ncp": "^2.0.0",
         "postcss": "^8.4.21",
         "prettier": "^2.8.3",
@@ -14426,16 +14426,17 @@
       "dev": true
     },
     "node_modules/linkfree-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.1.tgz",
-      "integrity": "sha512-xwEUhIoI5ZVojxn75hA6jC7CL/TQeAAaq4e0XRwHjCRm8reAKHVSZMXkjlZC6WrMmuUdnxtvIa3AA+4D0mhAgQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.2.2.tgz",
+      "integrity": "sha512-yyj9e7JU3nmIh8CATK6OCMnZb/DUccHTW1bWq8IB7UCkGHLUikCMyRxGIKpBsE9O9cYEr2qYG0kdghVWsHWzLw==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",
         "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
-        "open": "^8.4.2"
+        "open": "^8.4.2",
+        "react-icons": "^4.7.1"
       },
       "bin": {
         "linkfree-cli": "src/index.js"
@@ -31856,16 +31857,17 @@
       "dev": true
     },
     "linkfree-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.0.1.tgz",
-      "integrity": "sha512-xwEUhIoI5ZVojxn75hA6jC7CL/TQeAAaq4e0XRwHjCRm8reAKHVSZMXkjlZC6WrMmuUdnxtvIa3AA+4D0mhAgQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.2.2.tgz",
+      "integrity": "sha512-yyj9e7JU3nmIh8CATK6OCMnZb/DUccHTW1bWq8IB7UCkGHLUikCMyRxGIKpBsE9O9cYEr2qYG0kdghVWsHWzLw==",
       "dev": true,
       "requires": {
         "axios": "^0.27.2",
         "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
-        "open": "^8.4.2"
+        "open": "^8.4.2",
+        "react-icons": "^4.7.1"
       },
       "dependencies": {
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-config-next": "^13.1.6",
     "eslint-plugin-storybook": "^0.6.10",
     "husky": "^8.0.3",
-    "linkfree-cli": "^2.0.1",
+    "linkfree-cli": "^2.2.2",
     "ncp": "^2.0.0",
     "postcss": "^8.4.21",
     "prettier": "^2.8.3",


### PR DESCRIPTION
- Bump LinkFree-CLI version to `v2.2.2` to add support for new features

NPM Release - https://www.npmjs.com/package/linkfree-cli/v/2.2.2
Chnagelog - https://github.com/Pradumnasaraf/LinkFree-CLI/releases/tag/v2.2.2


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5541"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

