### PR TITLE
fix: memoize userdata prop passed to user profile component

### DIFF
--- a/components/user/UserPage.js
+++ b/components/user/UserPage.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import UserProfile from "./UserProfile";
 import UserTabs from "./UserTabs";
@@ -9,6 +9,24 @@ import UserEvents from "./UserEvents";
 
 export default function UserPage({ data, BASE_URL }) {
   const [userData, setUserData] = useState(data);
+
+  const userProfileData = useMemo(
+    () => ({
+      name: userData.name,
+      username: userData.username,
+      socials: userData.socials,
+      bio: userData.bio,
+      tags: userData.tags,
+    }),
+    [
+      userData.bio,
+      userData.name,
+      userData.socials,
+      userData.tags,
+      userData.username,
+    ]
+  );
+
   const defaultTabs = [
     { name: "My Links", href: "#", current: true, order: "ASC" },
     { name: "Milestones", href: "#", current: false, order: "ASC" },
@@ -41,7 +59,7 @@ export default function UserPage({ data, BASE_URL }) {
 
   return (
     <>
-      <UserProfile data={userData} BASE_URL={BASE_URL} />
+      <UserProfile data={userProfileData} BASE_URL={BASE_URL} />
       <UserTabs
         tabs={tabs}
         setTabs={setTabs}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
Closes #5535 

## Changes proposed
- Only pass data which is needed by user profile component.
- Currently all userData along with Links, Milestones ... were passed. So on changing sort order, data changes so userProfile components updates the component as data passed also contains Links/Milestones ... data. Though it is not needed in userProfile component.
- 
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5570"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

