### PR TITLE
Added a feature which disables the clear button when nothing is selected.

### DIFF
--- a/components/Badge.js
+++ b/components/Badge.js
@@ -7,6 +7,7 @@ export default function Badge({
   position,
   className,
   badgeClassName,
+  disable,
   children,
   display = true,
   onClick,
@@ -36,7 +37,11 @@ export default function Badge({
   const badge = (
     <div
       title={title}
-      className={`absolute inline-block rotate-0 skew-x-0 skew-y-0 scale-x-100 scale-y-100 py-1 px-1.5 text-xs leading-none text-center whitespace-nowrap align-baseline font-bold bg-orange-600 text-black rounded-full z-10 ${css} ${badgeClassName}`}
+      className={`absolute inline-block rotate-0 skew-x-0 skew-y-0 scale-x-100 scale-y-100 py-1 px-1.5 text-xs leading-none text-center whitespace-nowrap align-baseline font-bold bg-orange-600 ${
+        disable ? "text-[#EEEEEE]" : "text-black"
+      } ${
+        disable ? "bg-[#C2C2C2]" : "bg-orange-600"
+      } rounded-full z-10 ${css} ${badgeClassName}`}
       onClick={() => (onClick ? onClick() : null)}
     >
       {content}

--- a/components/Button.js
+++ b/components/Button.js
@@ -3,7 +3,7 @@ import Link from "./Link";
 export default function Button({
   text,
   primary = false,
-  disable = false,
+  disable,
   ...restProps
 }) {
   let className =
@@ -12,7 +12,7 @@ export default function Button({
     ? " text-white bg-indigo-600  hover:bg-indigo-700"
     : " text-indigo-600 hover:bg-indigo-50";
   className += disable
-    ? " border-2 border-red-600 hover:bg-red-600"
+    ? " border-2 border-red bg-[#f4f4f4] hover:bg-[#f3f3f3] opacity-[.5] text-[gray] cursor-not-allowed"
     : " cursor-pointer";
 
   const link = (

--- a/pages/map.js
+++ b/pages/map.js
@@ -56,8 +56,6 @@ export default function Map({ data }) {
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [selectedTags, setSelectedTags] = useState(new Set());
 
-  console.log(selectedTags);
-
   let results = [];
 
   const updateSelectedTagsFilter = (tagSelected) => {

--- a/pages/map.js
+++ b/pages/map.js
@@ -56,6 +56,8 @@ export default function Map({ data }) {
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [selectedTags, setSelectedTags] = useState(new Set());
 
+  console.log(selectedTags);
+
   let results = [];
 
   const updateSelectedTagsFilter = (tagSelected) => {
@@ -115,6 +117,7 @@ export default function Map({ data }) {
         </p>
         <div className="flex flex-wrap justify-center mb-4">
           <Badge
+            disable={selectedTags.size == 0 ? true : false}
             content={
               filteredUsers.length > 0 ? filteredUsers.length : users.length
             }
@@ -123,6 +126,7 @@ export default function Map({ data }) {
               onClick={resetFilter}
               text="Clear/Reset Filters"
               primary={false}
+              disable={selectedTags.size == 0 ? true : false}
             />
           </Badge>
           {tags &&


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #5500

closes #5500

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

Currently `Clear/Reset` button in Map section is active even when no filter is selected, hence a fix to this issue is proposed through my PR which disables the button if no filters are selected.

<!-- List all the proposed changes in your PR -->

Before:

<img width="1439" alt="Screenshot 2023-03-21 at 8 43 00 PM" src="https://user-images.githubusercontent.com/93585735/226651445-3d66c1d4-0998-499b-830c-4bf74b09a004.png">

After:

<img width="1440" alt="Screenshot 2023-03-21 at 8 45 31 PM" src="https://user-images.githubusercontent.com/93585735/226652092-b9677f82-01c9-4500-9786-7a2d880220d8.png">


<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5588"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

