### PR TITLE
Profile Progress section in the Account page

### DIFF
--- a/components/statistics/ProfileProgress.js
+++ b/components/statistics/ProfileProgress.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+const ProfileProgress = () => {
+    return (
+        <div className='w-full border p-4'>
+            <h3 className='text-lg font-medium leading-6 text-gray-900'>Profile Completion: <span className='text-indigo-600'>100%</span></h3>
+
+
+            <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+                <div class="bg-indigo-600 h-2.5 my-4 rounded-full" style={{"width": "45%"}}></div>
+            </div>
+
+            <div className="border p-4 my-4">
+                fsdfd
+            </div>
+
+        </div>
+    )
+}
+
+export default ProfileProgress

--- a/components/statistics/ProfileProgress.js
+++ b/components/statistics/ProfileProgress.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const ProfileProgress = ({ progress }) => {
     return (
         <div className='w-full border p-4 my-6'>

--- a/components/statistics/ProfileProgress.js
+++ b/components/statistics/ProfileProgress.js
@@ -6,7 +6,7 @@ const ProfileProgress = ({ progress }) => {
             <h3 className='text-lg font-medium leading-6 text-gray-900'>Profile Completion: <span className='text-indigo-600'>{progress.percentage} %</span></h3>
 
 
-            <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-600">
+            <div class="w-full bg-gray-200 rounded-full h-2.5">
                 <div class="bg-indigo-600 h-2.5 my-4 rounded-full" style={{ "width": `${progress.percentage}%` }}></div>
             </div>
         </div>

--- a/components/statistics/ProfileProgress.js
+++ b/components/statistics/ProfileProgress.js
@@ -1,19 +1,45 @@
 import React from 'react'
+import {
+    MdOutlinePlayArrow,
+    MdHelpOutline,
+    MdOutlineLink,
+    MdOutlinePersonPin,
+    MdOutlineAutoGraph,
+    MdOutlineEditCalendar,
+} from "react-icons/md";
 
-const ProfileProgress = () => {
+const ProfileProgress = ({ progress }) => {
     return (
-        <div className='w-full border p-4'>
-            <h3 className='text-lg font-medium leading-6 text-gray-900'>Profile Completion: <span className='text-indigo-600'>100%</span></h3>
+        <div className='w-full border p-4 my-6'>
+            <h3 className='text-lg font-medium leading-6 text-gray-900'>Profile Completion: <span className='text-indigo-600'>{progress.percentage} %</span></h3>
 
 
-            <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
-                <div class="bg-indigo-600 h-2.5 my-4 rounded-full" style={{"width": "45%"}}></div>
+            <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-600">
+                <div class="bg-indigo-600 h-2.5 my-4 rounded-full" style={{ "width": `${progress.percentage}%` }}></div>
             </div>
 
-            <div className="border p-4 my-4">
-                fsdfd
+            <div className="border p-4 my-4 gap-4 flex items-center justify-start">
+                <MdHelpOutline className="h-8 w-8 text-indigo-600"
+                    aria-hidden="true" />
+                <h3>Add social icons to your profile</h3>
             </div>
-
+            <div className="flex justify-between p-2">
+                <div className="flex gap-2">
+                    <button className='text-gray-900 text-lg flex gap-1 justify-center items-center'>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                        </svg>
+                        Prev
+                    </button>
+                    <button className='text-gray-900 text-lg flex gap-1 justify-center items-center'>
+                        Next
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                    </button>
+                </div>
+                <button className='bg-indigo-600 text-white py-2 px-4 rounded-lg' >Learn More</button>
+            </div>
         </div>
     )
 }

--- a/components/statistics/ProfileProgress.js
+++ b/components/statistics/ProfileProgress.js
@@ -1,12 +1,4 @@
 import React from 'react'
-import {
-    MdOutlinePlayArrow,
-    MdHelpOutline,
-    MdOutlineLink,
-    MdOutlinePersonPin,
-    MdOutlineAutoGraph,
-    MdOutlineEditCalendar,
-} from "react-icons/md";
 
 const ProfileProgress = ({ progress }) => {
     return (
@@ -16,29 +8,6 @@ const ProfileProgress = ({ progress }) => {
 
             <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-600">
                 <div class="bg-indigo-600 h-2.5 my-4 rounded-full" style={{ "width": `${progress.percentage}%` }}></div>
-            </div>
-
-            <div className="border p-4 my-4 gap-4 flex items-center justify-start">
-                <MdHelpOutline className="h-8 w-8 text-indigo-600"
-                    aria-hidden="true" />
-                <h3>Add social icons to your profile</h3>
-            </div>
-            <div className="flex justify-between p-2">
-                <div className="flex gap-2">
-                    <button className='text-gray-900 text-lg flex gap-1 justify-center items-center'>
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-                        </svg>
-                        Prev
-                    </button>
-                    <button className='text-gray-900 text-lg flex gap-1 justify-center items-center'>
-                        Next
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                        </svg>
-                    </button>
-                </div>
-                <button className='bg-indigo-600 text-white py-2 px-4 rounded-lg' >Learn More</button>
             </div>
         </div>
     )

--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -67,8 +67,7 @@ export async function getServerSideProps(context) {
       "milestones",
       "tags",
       "socials",
-      "location",
-      "kakaka"
+      "location"
     ]
 
     progress = {

--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -85,8 +85,6 @@ export async function getServerSideProps(context) {
 
     progress.missing = profileSections.filter((property)=> !Object.keys(profile).includes(property) )
     progress.percentage = (((profileSections.length - progress.missing.length) / profileSections.length)*100).toFixed(2) 
-    console.log(progress);
-
 
   } catch (e) {
     logger.error(e, "ERROR get user's account statistics");
@@ -97,7 +95,7 @@ export async function getServerSideProps(context) {
   };
 }
 
-export default function Statistics({ data, profile,missing }) {
+export default function Statistics({ data, profile,progress }) { 
   const dateTimeStyle = {
     dateStyle: "short",
   };
@@ -127,8 +125,6 @@ export default function Statistics({ data, profile,missing }) {
     },
   ];
 
-  console.log(missing,profile);
-
   return (
     <>
       <PageHead
@@ -137,7 +133,7 @@ export default function Statistics({ data, profile,missing }) {
       />
 
       <Page>
-        <ProfileProgress profile={profile}/>
+        <ProfileProgress progress={progress}/>
         <h1 className="text-4xl mb-4 font-bold">
           Your Statistics for {profile.name} ({profile.username})
         </h1>

--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -1,5 +1,6 @@
 import { authOptions } from "../api/auth/[...nextauth]";
 import { unstable_getServerSession } from "next-auth/next";
+import ProfileProgress from "../../components/statistics/ProfileProgress"
 
 import {
   BarChart,
@@ -55,6 +56,7 @@ export async function getServerSideProps(context) {
   }
 
   let data = {};
+  let progress
   try {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/api/account/statistics`,
@@ -65,16 +67,37 @@ export async function getServerSideProps(context) {
       }
     );
     data = await res.json();
+
+    let profileSections = [
+      "bio",
+      "links",
+      "milestones",
+      "tags",
+      "socials",
+      "location",
+      "kakaka"
+    ]
+
+    progress = {
+      percentage:0,
+      missing:[]
+    }
+
+    progress.missing = profileSections.filter((property)=> !Object.keys(profile).includes(property) )
+    progress.percentage = (((profileSections.length - progress.missing.length) / profileSections.length)*100).toFixed(2) 
+    console.log(progress);
+
+
   } catch (e) {
     logger.error(e, "ERROR get user's account statistics");
   }
 
   return {
-    props: { session, data, profile },
+    props: { session, data, profile, progress},
   };
 }
 
-export default function Statistics({ data, profile }) {
+export default function Statistics({ data, profile,missing }) {
   const dateTimeStyle = {
     dateStyle: "short",
   };
@@ -104,6 +127,8 @@ export default function Statistics({ data, profile }) {
     },
   ];
 
+  console.log(missing,profile);
+
   return (
     <>
       <PageHead
@@ -112,6 +137,7 @@ export default function Statistics({ data, profile }) {
       />
 
       <Page>
+        <ProfileProgress profile={profile}/>
         <h1 className="text-4xl mb-4 font-bold">
           Your Statistics for {profile.name} ({profile.username})
         </h1>

--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -49,7 +49,6 @@ export async function getServerSideProps(context) {
   }
 
   let data = {};
-  let progress
   try {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/api/account/statistics`,
@@ -61,33 +60,36 @@ export async function getServerSideProps(context) {
     );
     data = await res.json();
 
-    let profileSections = [
-      "bio",
-      "links",
-      "milestones",
-      "tags",
-      "socials",
-      "location"
-    ]
 
-    progress = {
-      percentage:0,
-      missing:[]
-    }
-
-    progress.missing = profileSections.filter((property)=> !Object.keys(profile).includes(property) )
-    progress.percentage = (((profileSections.length - progress.missing.length) / profileSections.length)*100).toFixed(2) 
 
   } catch (e) {
     logger.error(e, "ERROR get user's account statistics");
   }
 
+  let profileSections = [
+    "bio",
+    "links",
+    "milestones",
+    "tags",
+    "socials",
+    "location",
+    "testimonials",
+  ];
+
+  let progress = {
+    percentage: 0,
+    missing: [],
+  };
+
+  progress.missing = profileSections.filter((property) => !Object.keys(profile).includes(property))
+  progress.percentage = (((profileSections.length - progress.missing.length) / profileSections.length) * 100).toFixed(2)
+
   return {
-    props: { session, data, profile, progress},
+    props: { session, data, profile, progress },
   };
 }
 
-export default function Statistics({ data, profile,progress }) { 
+export default function Statistics({ data, profile, progress }) {
   const dateTimeStyle = {
     dateStyle: "short",
   };
@@ -125,7 +127,7 @@ export default function Statistics({ data, profile,progress }) {
       />
 
       <Page>
-        <ProfileProgress progress={progress}/>
+        <ProfileProgress progress={progress} />
         <h1 className="text-4xl mb-4 font-bold">
           Your Statistics for {profile.name} ({profile.username})
         </h1>


### PR DESCRIPTION
## Fixes Issue

<!-- Remove this section if not applicable -->
closes #5496 

## Changes in the PR
Created UI for the progress bar using tailwind
![image](https://user-images.githubusercontent.com/51131670/227862320-0e09e5f0-ead4-48db-a06a-2efa9af0b841.png)
### Statistics page
Created a array which represents the sections that are required to fully complete the profile named it `profileSections`
```jsx
let profileSections = [
      "bio",
      "links",
      "milestones",
      "tags",
      "socials",
      "location"
    ]
```

Created an object called `progress` which keeps track of :
- The completion percentage
- An array of sections that are missing (This serves can be used later to add specific hints related to the missing sections below the progress bar )
```jsx
   progress = {
      percentage:0,
      missing:[]
    }
``` 

Used filter to find the missing items, calculated the percentage
```jsx
    progress.missing = profileSections.filter((property)=> !Object.keys(profile).includes(property) )
    progress.percentage = (((profileSections.length - progress.missing.length) / profileSections.length)*100).toFixed(2) 
```

Created the ProfileProgress component and displayed the data accordingly


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5617"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

