### PR TITLE
docs: add information on why user markers not appearing in local dev

### DIFF
--- a/pages/docs/map.mdx
+++ b/pages/docs/map.mdx
@@ -26,7 +26,7 @@ Contribution to the map or any other part of the LinkFree is detailed in the <Li
 
 In the current implementation, the location information of a user is only updated when they visit their specific profile page. Therefore, during local development, no user has their location information in the database, leading to the map page not displaying any user markers.
 
-To display user markers on the map page during local development, you need to visit multiple user profiles to populate the database with location information. This can be done by manually visiting the profiles. Once the database is populated with location information, the user markers will start appearing on the map.
+To display user markers on the map page during local development, you can run the automated tests. The automated tests will visit some user profiles and create location information in the database. This will allow the user markers to appear on the map. For more information on how to execute the automated tests, please refer to the [Automated Tests Doc](https://linkfree.eddiehub.io/docs/contributing/automated-tests). Alternatively, you can manually visit multiple user profiles to populate the database with location information.
 
 You can find the relevant code that retrieves the location information for each user in the [`getLocation.js`](https://github.com/EddieHubCommunity/LinkFree/blob/main/services/profiles/getLocation.js) file in the `services/profiles` directory.
 

--- a/pages/docs/map.mdx
+++ b/pages/docs/map.mdx
@@ -26,7 +26,7 @@ Contribution to the map or any other part of the LinkFree is detailed in the <Li
 
 In the current implementation, the location information of a user is only updated when they visit their specific profile page. Therefore, during local development, no user has their location information in the database, leading to the map page not displaying any user markers.
 
-To display user markers on the map page during local development, you need to visit multiple user profiles to populate the database with location information. This can be done by manually visiting the profiles or by creating a script that visits multiple profiles automatically. Once the database is populated with location information, the user markers will start appearing on the map.
+To display user markers on the map page during local development, you need to visit multiple user profiles to populate the database with location information. This can be done by manually visiting the profiles. Once the database is populated with location information, the user markers will start appearing on the map.
 
 You can find the relevant code that retrieves the location information for each user in the [`getLocation.js`](https://github.com/EddieHubCommunity/LinkFree/blob/main/services/profiles/getLocation.js) file in the `services/profiles` directory.
 

--- a/pages/docs/map.mdx
+++ b/pages/docs/map.mdx
@@ -22,8 +22,16 @@ If yes, you may ask in Discord for someone to take a look
 
 Contribution to the map or any other part of the LinkFree is detailed in the <Link href="/docs">contributing section</Link> of the docs page. We welcome all contributions.
 
+## Why are user markers not appearing on the map in the local development environment?
+
+In the current implementation, the location information of a user is only updated when they visit their specific profile page. Therefore, during local development, no user has their location information in the database, leading to the map page not displaying any user markers.
+
+To display user markers on the map page during local development, you need to visit multiple user profiles to populate the database with location information. This can be done by manually visiting the profiles or by creating a script that visits multiple profiles automatically. Once the database is populated with location information, the user markers will start appearing on the map.
+
+You can find the relevant code that retrieves the location information for each user in the [`getLocation.js`](https://github.com/EddieHubCommunity/LinkFree/blob/main/services/profiles/getLocation.js) file in the `services/profiles` directory.
+
+Note: This situation only affects the local development environment and not the production environment. In production, the user markers will appear on the map since the location information of all users is already available in the database.
+
 export default ({ children }) => (
   <DocsLayout title="LinkFree Map documentation">{children}</DocsLayout>
 );
-
-;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #5473 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
- Add information on why user markers not appearing in local dev to the [Map Information Doc](https://linkfree.io/docs/map)


<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![image](https://user-images.githubusercontent.com/7236196/229315950-a271ce99-e51e-4d60-bf9f-9191b2670dd8.png)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
The documentation now explains why user markers do not appear on the map page during local development and provide a solution to populate the database with location information. This change aims to help beginner developers who may face this issue while working on the project.

As discussed in issue #5473, I plan to create a new issue for adding a `seed` script to populate mock user location information to the database for local development purposes. This would make it easier for developers to test the map functionality without manually visiting multiple user profiles.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5766"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

