### PR TITLE
Closes #5812 add underline on event name on mouse hover

### DIFF
--- a/components/Link.js
+++ b/components/Link.js
@@ -5,9 +5,9 @@ export default function Link({ children, className, rel, ...restProps }) {
     <NextLink
       rel={rel ? rel : "noreferrer"}
       className={
-        className
+        `${className
           ? className
-          : "text-blue-600 underline decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid"
+          : "text-blue-600 underline decoration-dotted dark:text-blue-500 hover:decoration-solid"} hover:underline`
       }
       {...restProps}
     >

--- a/components/event/EventCard.js
+++ b/components/event/EventCard.js
@@ -43,7 +43,7 @@ export default function EventCard({ event, username }) {
                   key={event.url}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-lg lg:text-xl tracking-wide font-medium capitalize hover:underline"
+                  className="text-lg lg:text-xl tracking-wide font-medium capitalize"
                 >
                   {event.name}
                 </Link>

--- a/components/event/EventCard.js
+++ b/components/event/EventCard.js
@@ -43,7 +43,7 @@ export default function EventCard({ event, username }) {
                   key={event.url}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-lg lg:text-xl tracking-wide font-medium capitalize"
+                  className="text-lg lg:text-xl tracking-wide font-medium capitalize hover:underline"
                 >
                   {event.name}
                 </Link>


### PR DESCRIPTION
## Fixes Issue

Adds a visual effect on hover

Closes #5812

## Changes proposed

1. Add an underline on the Event name when mouse hover

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

Before Change
https://user-images.githubusercontent.com/116902573/229454158-175b1bd9-5db7-456f-a875-f325707c7e65.png

After Change
https://user-images.githubusercontent.com/72187009/229775180-09d0b1f0-188c-42b9-af42-36fc8523143a.png

## Note to reviewers

It's just a simple change that adds an underline to the event name when mouse is hovered over it


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5836"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

