### PR TITLE
add white text color to button on hover in light mode

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -10,11 +10,11 @@ export default function Button({
     "inline-flex items-center justify-center rounded-md border border-transparent px-5 py-3 text-base font-medium first-letter:bg-white";
   !disable
     ? (className += primary
-        ? " text-white bg-secondary-medium hover:bg-secondary-high"
-        : " text-secondary-high dark:text-secondary-high dark:hover:text-white dark:bg-secondary-low hover:bg-secondary-medium dark:hover:bg-secondary-medium")
+      ? " text-white bg-secondary-medium hover:bg-secondary-high"
+      : " text-secondary-high hover:text-white dark:text-secondary-high dark:hover:text-white dark:bg-secondary-low hover:bg-secondary-medium dark:hover:bg-secondary-medium")
     : (className += disable
-        ? " border-2 border-red border shadow-sm bg-primary-low text-primary-medium cursor-not-allowed "
-        : " cursor-pointer");
+      ? " border-2 border-red border shadow-sm bg-primary-low text-primary-medium cursor-not-allowed "
+      : " cursor-pointer");
 
   const link = (
     <Link className={className} {...restProps}>


### PR DESCRIPTION
## Changes proposed
On hovering the button in light mode the text color remains the same 
On dark mode it's white
So I added a small fix in the button component

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
Before :
![image](https://user-images.githubusercontent.com/76396808/230725423-5cd32837-c15f-4427-ab3c-9cbf8ded2e8c.png)
![image](https://user-images.githubusercontent.com/76396808/230725405-378ae7e7-c8bc-4f10-8465-8c73b73d7964.png)
After : 
![image](https://user-images.githubusercontent.com/76396808/230725438-288bdf5b-0b8d-48c6-8ac9-e6f6609180dd.png)
![image](https://user-images.githubusercontent.com/76396808/230725464-bb494c1e-f187-4a99-9982-2ec5e8621327.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5927"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

