### PR TITLE
Added another workflow in reviewpad.yml with the name mark-PR-blocked-if-not-status-ready-for-dev

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -100,3 +100,10 @@ workflows:
   #     - rule: check-for-status-block
   #   then:
   #     - '$addLabel("🚧 status: blocked")'
+  
+  - name: mark-PR-blocked-if-not-status-ready-for-dev
+    always-run: true
+    if: 
+      - '$isElementOf("🏁 status: ready for dev", $labels()) == false'
+    then:
+      - '$addLabel("🚧 status: blocked")'


### PR DESCRIPTION
changes to mark PR as blocked if the issue doesn't have label status: ready for dev

## Fixes Issue

[FEATURE] Mark PR as blocked if issue does not have label status: ready for dev

Closes #5511

Added another workflow in reviewpad.yml with the name mark-PR-blocked-if-not-status-ready-for-dev

- [ X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ X] This PR does not contain plagiarized content.
- [ X] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/5947"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

