### PR TITLE
Removed Extra backtick in docs

### DIFF
--- a/pages/docs/environments/environment-variables.mdx
+++ b/pages/docs/environments/environment-variables.mdx
@@ -17,7 +17,7 @@ Environment variables are needed in the `.env` file to allow the application to 
 
 ### GitHub OAuth
 
-1. Go to your profile `settings``
+1. Go to your profile `settings`
 2. Then `Developer settings` down the bottom left
 3. Click `New OAuth app` and fill in the form details
 


### PR DESCRIPTION
Closes #6008 

Changes : 

In environment-variables.mdx 
From :
1. Go to your profile `settings``
To :
1. Go to your profile `settings`

Screenshots :
![Removes extra backtick](https://user-images.githubusercontent.com/112814295/231434917-a881adda-5ead-4756-8e84-ca503eb54492.png)
