### PR TITLE
User profile reset issue - SearchBar

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -105,6 +105,10 @@ export default function Search({ data }) {
 
   useEffect(() => {
     if (!inputValue) {
+      //Setting the users as null when the input field is empty
+      setFilteredUsers([]);
+      //Removing the not found field when the input field is empty
+      setNotFound();
       return;
     }
 


### PR DESCRIPTION
Hi @eddiejaoude this is regarding Toggle information in the search bar and the profile panel reset issue #6002

I have made some code changes such that the Badge in the search bar be zero and the profile panel be empty when the search field is empty

The code changes fixes this #6002 issue

fixes #6002 

![image](https://user-images.githubusercontent.com/27686539/231515055-2e79ce9b-b205-411b-afb5-291a2fe7e589.png)
![image](https://user-images.githubusercontent.com/27686539/231515241-e79430f4-8ebb-48c3-8cc0-dd298a4ea62e.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6030"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

