### PR TITLE
Remove line-clamp plugin as the functinality is now built into tailwind core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "linkfree",
-      "version": "1.109.15",
+      "version": "1.109.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,6 @@
         "@mdx-js/react": "^2.3.0",
         "@next/mdx": "^13.2.4",
         "@tailwindcss/forms": "^0.5.3",
-        "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.9",
         "autoprefixer": "^10.4.14",
         "dotenv": "^16.0.3",
@@ -6679,14 +6678,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
-      }
-    },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
-      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/typography": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@mdx-js/react": "^2.3.0",
     "@next/mdx": "^13.2.4",
     "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.14",
     "dotenv": "^16.0.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,6 +33,5 @@ module.exports = {
   plugins: [
     require("@tailwindcss/typography"),
     require("@tailwindcss/forms"),
-    require("@tailwindcss/line-clamp"),
   ],
 };


### PR DESCRIPTION
## Changes proposed
Remove the line-clamp plugin to get rid of the warning from tailwind

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6108"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

