### PR TITLE
docs: changed the old URL #6341

### DIFF
--- a/pages/docs/environments/environment-variables.mdx
+++ b/pages/docs/environments/environment-variables.mdx
@@ -24,7 +24,7 @@ Environment variables are needed in the `.env` file to allow the application to 
 | Form field                 | value                                            |
 | :------------------------- | :----------------------------------------------- |
 | Application name           | `LinkFree local`                                 |
-| Homepage URL               | `http://linkfree.eddiehub.io`                    |
+| Homepage URL               | `https://linkfree.io`                    |
 | Application description    | `Open Source alternative to LinkTree`            |
 | Authorization callback URL | `http://localhost:3000/api/auth/callback/github` |
 


### PR DESCRIPTION
Fixed #6341

Just changed the domain to `https://linkfree.io`


![image](https://user-images.githubusercontent.com/88102392/234070053-abd61e97-27d4-4047-9004-74a1afd2adff.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

