### PR TITLE
force IPv4 on mongoose connect

### DIFF
--- a/config/mongo.js
+++ b/config/mongo.js
@@ -23,7 +23,7 @@ const connectMongo = async () => {
 
     hasConnection = await mongoose.connect(
       process.env.LINKFREE_MONGO_CONNECTION_STRING,
-      { autoIndex: true }
+      { autoIndex: true, family: 4 }
     );
     hasConnection = true;
     logger.info("MongoDB connected");


### PR DESCRIPTION
## Changes proposed
Force mongoose to connect by IPv4
GitPod is now configured with IPv6 available which is causing connection errors trying to access `::1`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6389"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

