### PR TITLE
ci: Improve message of issue locking Action

### DIFF
--- a/.github/workflows/issue-lock.yml
+++ b/.github/workflows/issue-lock.yml
@@ -18,4 +18,4 @@ jobs:
           process-only: "issues"
           skip-closed-issue-comment: true
           issue-comment: >
-           To reduce notifications, issues are locked until they are ready for dev and to be assigned
+           To reduce notifications, issues are locked until they are https://github.com/EddieHubCommunity/LinkFree/labels/%F0%9F%8F%81%20status%3A%20ready%20for%20dev and to be assigned


### PR DESCRIPTION
## Changes proposed

GitHub supports the rendering of issue labels in Markdown. Now, Instead of plain `ready for dev` text, now it will show the actual issue label, and it's clickable as well.

## Preview

_To reduce notifications, issues are locked until they are https://github.com/EddieHubCommunity/LinkFree/labels/%F0%9F%8F%81%20status%3A%20ready%20for%20dev and to be assigned_


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

