### PR TITLE
Use Mongoose aggregate to sum views & clicks

### DIFF
--- a/pages/api/statistics/totals.js
+++ b/pages/api/statistics/totals.js
@@ -20,9 +20,9 @@ export default async function handler(req, res) {
 export async function getTotalStats() {
   await connectMongo();
 
-  let dailyStats = [];
+  let totalStats = [];
   try {
-    dailyStats = await Stats.aggregate([{
+    totalStats = await Stats.aggregate([{
       $group: {
         _id: null,
         totalViews:  { $sum: "$views" },
@@ -53,8 +53,8 @@ export async function getTotalStats() {
   return {
     statusCode: 200,
     stats: {
-      views: dailyStats[0]?.totalViews || 0,
-      clicks: dailyStats[0]?.totalClicks || 0,
+      views: totalStats[0]?.totalViews || 0,
+      clicks: totalStats[0]?.totalClicks || 0,
       users: totalProfiles.length || 0,
       active: activeProfiles || 0,
     },

--- a/pages/api/statistics/totals.js
+++ b/pages/api/statistics/totals.js
@@ -22,17 +22,16 @@ export async function getTotalStats() {
 
   let dailyStats = [];
   try {
-    dailyStats = await Stats.find({});
+    dailyStats = await Stats.aggregate([{
+      $group: {
+        _id: null,
+        totalViews:  { $sum: "$views" },
+        totalClicks: { $sum: "$clicks" },
+      }
+    }]);
   } catch (e) {
     logger.error(e, "failed to load stats");
   }
-
-  let views = 0;
-  let clicks = 0;
-  dailyStats.forEach((stat) => {
-    views += stat.views;
-    clicks += stat.clicks;
-  });
 
   let activeProfiles = 0;
   try {
@@ -54,8 +53,8 @@ export async function getTotalStats() {
   return {
     statusCode: 200,
     stats: {
-      views,
-      clicks,
+      views: dailyStats[0]?.totalViews || 0,
+      clicks: dailyStats[0]?.totalClicks || 0,
       users: totalProfiles.length || 0,
       active: activeProfiles || 0,
     },


### PR DESCRIPTION
## Changes proposed
Currently the total views & clicks stats for the index page are obtained by getting an array of stats from MongoDB, then looping over the array to sum the values.
This PR uses the MongoDB aggregate function to get the database to sum the values for us.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6539"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

