### PR TITLE
(fix): date visibility on stats page

### DIFF
--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -181,7 +181,9 @@ export default function Statistics({ data, profile, progress }) {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="date" />
                 <YAxis />
-                <Tooltip />
+                <Tooltip contentStyle={{
+                  color: "black"
+                }} />
                 <Bar dataKey="views" fill="#82ca9d" />
               </BarChart>
             </ResponsiveContainer>


### PR DESCRIPTION
fixes #6532 

By adding some style it solves the problem of not showing the date in the tooltip of profile visit count.
Here is how `it was` vs `it is` 

| Then | Now |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/77217706/235549951-c4f7f195-1d88-41b0-ae11-c43707887246.png) | ![image](https://user-images.githubusercontent.com/77217706/235549981-0ba0069c-a3ab-4b0e-85cf-0acf7be7a98c.png) | 

### `The code that solved the problem`
```js
 <Tooltip contentStyle={{
    color: "black"
  }} />
  ```

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6549"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

