### PR TITLE
Dockerfile: Upgrade Node.js docker image to 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:20
 LABEL org.opencontainers.image.source https://github.com/eddiehubcommunity/LinkFree
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
* Node.js 16 (LTS) will go End-of-Life in September 2023
* Node.js 20 will enter long-term support (LTS) in October


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6644"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

