### PR TITLE
ci: update cron time - prettier.yml

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,9 +1,9 @@
 name: Format
 on:
   workflow_dispatch:
-  #Run every day at midnight UTC
+  #Runs at 01:01 UTC
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "1 1 * * *"
 
 concurrency:
   group: "main-branch"


### PR DESCRIPTION
## Changes proposed

Change the cron time from `12:00 UTC` to `01:01 UTC` because most actions run at that time on GitHub, and this will reduce the overall load. This was also recommended by @martinwoodward in one of Eddie's live streams.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6655"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

