### PR TITLE
Preload Map Tiles

### DIFF
--- a/components/PageHead.js
+++ b/components/PageHead.js
@@ -10,6 +10,8 @@ export default function PageHead(props) {
     ogType = "image/png",
   } = props;
 
+  const children = props.children;
+
   return (
     <Head>
       <title>{title}</title>
@@ -20,6 +22,7 @@ export default function PageHead(props) {
       <meta property="og:type" content={ogType} />
       <meta property="og:url" content={ogUrl} />
       <meta property="og:image" content={ogImage} />
+      {children}
     </Head>
   );
 }

--- a/components/map/Map.js
+++ b/components/map/Map.js
@@ -25,7 +25,7 @@ export default function Map({ users }) {
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          url="https://b.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <MarkerCluster>
           {users.map((user) => (

--- a/pages/map.js
+++ b/pages/map.js
@@ -96,12 +96,22 @@ export default function Map({ data }) {
     setSelectedTags(new Set());
   };
 
+  const tiles = [0,1,2,3];
+  let links = [];
+  for (const i of tiles) {
+    for (const j of tiles) {
+      links.push(<link rel="preload" as="image" key={`${i}${j}`} href={`https://a.tile.openstreetmap.org/2/${i}/${j}.png`}/>)
+    }
+  }
+
   return (
     <>
       <PageHead
         title="LinkFree Users Around The World"
         description="This map shows all the locations of LinkFree users based on the location provided in their GitHub profiles."
-      />
+      >
+        {links}
+      </PageHead>
       <Page>
         <h1 className="text-4xl mb-4 font-bold">
           LinkFree Users Around The World

--- a/pages/map.js
+++ b/pages/map.js
@@ -96,11 +96,10 @@ export default function Map({ data }) {
     setSelectedTags(new Set());
   };
 
-  const tiles = [0,1,2,3];
   let links = [];
-  for (const i of tiles) {
-    for (const j of tiles) {
-      links.push(<link rel="preload" as="image" key={`${i}${j}`} href={`https://a.tile.openstreetmap.org/2/${i}/${j}.png`}/>)
+  for (let i = 0; i <= 3; i++) {
+    for (let j = 0; j <= 3; j++) {
+      links.push(<link rel="preload" as="image" key={`${i}${j}`} href={`https://b.tile.openstreetmap.org/2/${i}/${j}.png`}/>)
     }
   }
 


### PR DESCRIPTION
## Changes proposed
The background of the map is a tiled collection of PNGs.
Because the map generation runs on the client, the request of these images happens later and slows down the loading.
This PR will preload all the images for the start zoom level.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/6961"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

