### PR TITLE
Use secret file to pass Mongo URL to docker build

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
       - name: get-npm-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
       - name: set up Docker builder
         uses: docker/setup-buildx-action@v2
       - name: log into GitHub Container Registry

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -47,6 +47,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
+      - name: Setup Env
+        run: echo "LINKFREE_MONGO_CONNECTION_STRING=${{ secrets.LINKFREE_MONGO_CONNECTION_STRING }}" > /tmp/.env
       - name: push to Github Container Registry
         uses: docker/build-push-action@v3
         with:
@@ -55,7 +57,8 @@ jobs:
           push: true
           secrets: |
             'GH_TOKEN=${{ secrets.GITHUB_TOKEN }}'
-          build-args: "github_token=${{ secrets.GITHUB_TOKEN }},MONGODB_URL=${{ secrets.LINKFREE_MONGO_CONNECTION_STRING }}"
+          secret-files: "MONGO=/tmp/.env"
+          build-args: "github_token=${{ secrets.GITHUB_TOKEN }}"
           tags: |
             ghcr.io/eddiehubcommunity/linkfree:v${{ steps.package-version.outputs.current-version}}
             ghcr.io/eddiehubcommunity/linkfree:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY . .
 
 RUN sed -i 's/0.0.0/'`npm pkg get version | tr -d '"'`'/g' config/app.json
 
-ARG MONGODB_URL
-RUN export LINKFREE_MONGO_CONNECTION_STRING=${MONGODB_URL} && npm run build
+RUN --mount=type=secret,id=MONGO,target=./.env npm run build
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Changes proposed
use the `secret-files` option on the docker build action to pass the MongoDB URL in securely

Docker Documentation
https://docs.docker.com/engine/reference/commandline/buildx_build/#secret
https://docs.docker.com/engine/reference/builder/#run---mounttypesecret

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7031"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

