### PR TITLE
tweaked primary color low-high in tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
           // slate
           "low": "rgb(249 250 251)",
           "low-medium":"rgb(143 151 166)",
-          "low-high":"rgb(121 129 140)",
+          "low-high":"rgb(163 163 159)",
           "medium-low":"rgb(111 118 128)",
           "medium": "rgb(35,48,66)",
           "high": "rgb(17 24 39)",


### PR DESCRIPTION
Closes #6572

## Fixes Issue

Passes accessibility criteria of color contrast in dark mode:
As the color contrast ratio of foreground color[ rgb(163 163 159]=(hex value= #A3A39F) to the background color(#111827) is found 7:1 that meets the minimum criteria as required.

## Changes proposed

```diff
- "low-high":"rgb(121 129 140)",
+ "low-high":"rgb(163 163 159)",
```

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="740" alt="Screenshot" src="https://github.com/EddieHubCommunity/LinkFree/assets/90052329/79972403-6379-4218-890b-0742d53e1d71">

## Note to reviewers

The issue has the label:"🏁 status: ready for dev" but the conversation has locked that's why I was unable to assign it before working on this issue and creating the pull request


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7054"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

