### PR TITLE
Don't prefetch nav links on mobile

### DIFF
--- a/components/navbar/NavLink.js
+++ b/components/navbar/NavLink.js
@@ -1,6 +1,8 @@
 import Link from "@components/Link";
 
 export default function NavLink({ path, item, mode, setIsOpen, onClick }) {
+  const prefetch = mode === "mobile" ? {prefetch: false} : {};
+
   let className =
     "text-primary-low hover:ring-2 hover:ring-primary-medium dark:hover:ring-secondary-low hover:text-secondary-low px-3 py-2 rounded-md text-sm font-medium";
 
@@ -23,7 +25,7 @@ export default function NavLink({ path, item, mode, setIsOpen, onClick }) {
     <Link
       href={item.url}
       className={className}
-      prefetch={mode !== "mobile"}
+      {...prefetch}
       aria-current="page"
       onClick={(e) => {
         setIsOpen && setIsOpen(false);

--- a/components/navbar/NavLink.js
+++ b/components/navbar/NavLink.js
@@ -23,6 +23,7 @@ export default function NavLink({ path, item, mode, setIsOpen, onClick }) {
     <Link
       href={item.url}
       className={className}
+      prefetch={mode !== "mobile"}
       aria-current="page"
       onClick={(e) => {
         setIsOpen && setIsOpen(false);


### PR DESCRIPTION
## Changes proposed
By default, Next pre-fetches links.
On mobile, with less powered devices on lower bandwidth networks, this can cause performance issues.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

