### PR TITLE
Load map markers in chunks to minimize blocking

### DIFF
--- a/components/map/MarkerCluster.js
+++ b/components/map/MarkerCluster.js
@@ -5,7 +5,7 @@ import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 
 function createMarkerCluster({ children: _c, ...props }, context) {
-  const clusterProps = {};
+  const clusterProps = {chunkedLoading: true};
   const clusterEvents = {};
 
   Object.entries(props).forEach(([propName, prop]) =>


### PR DESCRIPTION
## Changes proposed
The map loads markers for all users on initial load.
This PR tells leaflet to load in chunks to avoid hogging the main thread.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
