### PR TITLE
fix : duplicate tags in search #5534

### DIFF
--- a/pages/api/discover/tags.js
+++ b/pages/api/discover/tags.js
@@ -21,7 +21,7 @@ export async function getTags() {
       },
       {
         $group: {
-          _id: "$tags",
+          _id: { $toLower: "$tags" },
           total: { $sum: 1 },
         },
       },


### PR DESCRIPTION

## Closes #4676 

## Changes proposed

have used the MongoDB aggregation framework to convert tags to lowercase using the "$toLower" operator


## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/EddieHubCommunity/LinkFree/assets/29349136/5d716a93-dbb9-4d91-b7b4-d82290e1a13e)

## Note to reviewers

Hey [this](https://github.com/EddieHubCommunity/LinkFree/pull/5534#discussion_r1208740227) i have checked 
as in [Search.js](https://github.com/EddieHubCommunity/LinkFree/blob/main/pages/search.js) the tags already converted to lowercase 
![image](https://github.com/EddieHubCommunity/LinkFree/assets/29349136/57c95d40-c07c-46f6-a55f-7e5b484a3fde)

As here the results returning filtered value only 
Also have checked and tested by my side every tag is working fine 
Need Your reviews Thanks 


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7249"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

