### PR TITLE
Fix events display in local timezone

### DIFF
--- a/components/event/EventCard.js
+++ b/components/event/EventCard.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { FaMicrophoneAlt, FaMapPin } from "react-icons/fa";
 import {
   MdOutlineOnlinePrediction,
@@ -13,18 +13,20 @@ import FallbackImage from "@components/FallbackImage";
 
 export default function EventCard({ event, username }) {
   const fallbackImageSize = 60;
+  const [startTime, setStartTime] = useState(event.date.startFmt)
+  const [endTime, setEndTime] = useState(event.date.endFmt)
   
   useEffect((() => {
     const dateTimeStyle = {
       dateStyle: "full",
       timeStyle: "long",
     };
-    event.date.startFmt = new Intl.DateTimeFormat("en-GB", dateTimeStyle).format(
+    setStartTime( new Intl.DateTimeFormat("en-GB", dateTimeStyle).format(
       new Date(event.date.start)
-    );
-    event.date.endFmt = new Intl.DateTimeFormat("en-GB", dateTimeStyle).format(
+    ));
+    setEndTime( new Intl.DateTimeFormat("en-GB", dateTimeStyle).format(
       new Date(event.date.end)
-    );
+    ));
   }),[event.date])
 
   return (
@@ -72,11 +74,11 @@ export default function EventCard({ event, username }) {
               </div>
               <p className="text-sm text-primary-high dark:text-primary-low flex flex-col lg:flex-row gap-2">
                 <span>
-                  {event.date.startFmt}
+                  {startTime}
                 </span>
                 <MdOutlineArrowRightAlt className="self-center hidden lg:block" />
                 <span>
-                  {event.date.endFmt}
+                  {endTime}
                 </span>
               </p>
               <ReactMarkdown className="text-sm text-primary-medium dark:text-primary-low-medium py-1 flex-wrap">


### PR DESCRIPTION
## Changes proposed
Modifying a prop inside a component does not force a re-render.
Use state to manage the formatted start & end times to re-render the local time.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
