### PR TITLE
fix: change GHCR image versioning pattern

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -60,5 +60,5 @@ jobs:
           secret-files: "MONGO=/tmp/.env"
           build-args: "github_token=${{ secrets.GITHUB_TOKEN }}"
           tags: |
-            ghcr.io/eddiehubcommunity/linkfree:v${{ steps.package-version.outputs.current-version}}
+            ghcr.io/eddiehubcommunity/linkfree:${{ steps.package-version.outputs.current-version}}
             ghcr.io/eddiehubcommunity/linkfree:latest


### PR DESCRIPTION
## Issue

Closes #7281

## Changes proposed

I realise we were versioning the GHCR image incorrectly. The Docker image should be versioned like `image-name:version` eg: `mongo:6.0` without a `v`

Image from LinkFree GHCR image

<img width="674" alt="Screenshot 2023-05-31 at 1 06 33 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/51878265/b421bfa4-1553-4ef3-939e-d2f6ae85dee6">




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7280"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

