### PR TITLE
Closes #6967: <a> tag and <li> misalignment issue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+/pages/docs/quickstart.mdx

--- a/pages/docs/quickstart.mdx
+++ b/pages/docs/quickstart.mdx
@@ -158,15 +158,9 @@ An approving review from one of LinkFree's maintainers will show a green check m
 
 Looking for inspiration? You can view the following profiles for an example:
 
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json">
-    Eddie Jaoude
-  </Link>
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/amandamartin-dev.json">
-    Amanda Martin
-  </Link>
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json">
-    Pradumna Saraf
-  </Link>
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json">Eddie Jaoude</Link>
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/amandamartin-dev.json">Amanda Martin</Link>
+- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json">Pradumna Saraf</Link>
 
 ## Next steps
 


### PR DESCRIPTION
## Fixes Issue
Where \<a> tag and \<li> are misaligned in certain browsers (See screenshots)

Closes #6967

## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Broken
![Firefox - Broken](https://github.com/EddieHubCommunity/LinkFree/assets/18102814/21f5fac5-c295-4083-8079-244862885119)

Fixed
![Firefox - Fixed](https://github.com/EddieHubCommunity/LinkFree/assets/18102814/1e447ae9-303f-4a8c-94ab-56e574b078f7)

## Note to reviewers

Pre HTML5 \<a> tags could not contain \<p> tags. In HTML5 it is acceptable, however some browsers are flakey about the implementation. Removing the space in the \<Link> (\<a>) on lines 161-163 (docs/quickstart.mdx) removes the \<p> tag and fixes the issue. 

I was unable to find a way to comment out specific lines to prettier in .mdx format and had to add the file to .prettierignore, else saving the file adds the spaces and thus the \<p> tags back. 

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7300"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

