### PR TITLE
Limit MongoDB connections

### DIFF
--- a/config/mongo.js
+++ b/config/mongo.js
@@ -17,7 +17,11 @@ const connectMongo = async () => {
   }
 
   try {
-    const options = { autoIndex: true, family: 4 };
+    const options = {
+      autoIndex: true,
+      family: 4,
+      maxPoolSize: 10
+    };
     connection = await mongoose.connect(
       LINKFREE_MONGO_CONNECTION_STRING,
       options


### PR DESCRIPTION
## Changes proposed
Since next routes on Vercel run in serverless functions, they don't need 100 connections.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
