### PR TITLE
fix: add responsive height to youtube embeds (#7273)

### DIFF
--- a/components/embeds/Youtube.js
+++ b/components/embeds/Youtube.js
@@ -4,7 +4,7 @@ export default function Youtube({ url, title }) {
       <iframe
         src={url}
         title={title}
-        className="aspect-video w-full"
+        className="aspect-video w-full h-60 sm:h-80 md:h-[32rem] lg:h-[40rem]"
         allow="accelerometer; autoplay;"
         allowFullScreen
       ></iframe>


### PR DESCRIPTION
## Fixes Issue

Closes #7273 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Smaller screens -->

<details>
<summary>Smaller screens - Before</summary>

![Before change on smaller screens](https://github.com/EddieHubCommunity/LinkFree/assets/49006567/cc049403-2a12-4d6d-a511-20d755455a18)
</details>

<details>
<summary>Smaller screens - After</summary>

![After change on smaller screens](https://github.com/EddieHubCommunity/LinkFree/assets/49006567/88149a1d-415b-488b-9d68-4c8e69431196)
</details>

<!-- Larger screens -->

<details>
<summary>Larger screens - Before</summary>

![Before change on larger screens](https://github.com/EddieHubCommunity/LinkFree/assets/49006567/9a20a3d1-aef9-4bf5-a16a-2e4637e2201f)

</details>

<details>
<summary>Larger screens - After</summary>

![After change on larger screens](https://github.com/EddieHubCommunity/LinkFree/assets/49006567/958ca0c3-8945-4c1f-ad66-387e6ceb000a)

</details>


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

