### PR TITLE
fix: update linkfree-cli version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-config-next": "^13.4.3",
         "eslint-plugin-storybook": "^0.6.12",
         "husky": "^8.0.3",
-        "linkfree-cli": "^2.2.2",
+        "linkfree-cli": "^2.3.1",
         "postcss": "^8.4.23",
         "prettier": "^2.8.8",
         "storybook": "^7.0.15",
@@ -13885,9 +13885,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkfree-cli": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.2.2.tgz",
-      "integrity": "sha512-yyj9e7JU3nmIh8CATK6OCMnZb/DUccHTW1bWq8IB7UCkGHLUikCMyRxGIKpBsE9O9cYEr2qYG0kdghVWsHWzLw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/linkfree-cli/-/linkfree-cli-2.3.1.tgz",
+      "integrity": "sha512-4ex1lR2wifGq0thKQUzu1SwkjaRzSKd5s+d0FOQD8ZhnzoVZgeN38m/ZHKfz+DLhA5MhdIy5CGxIu4hKWiko0g==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-config-next": "^13.4.3",
     "eslint-plugin-storybook": "^0.6.12",
     "husky": "^8.0.3",
-    "linkfree-cli": "^2.2.2",
+    "linkfree-cli": "^2.3.1",
     "postcss": "^8.4.23",
     "prettier": "^2.8.8",
     "storybook": "^7.0.15",


### PR DESCRIPTION
## Changes proposed

Bump the [linkfree-cli](https://www.npmjs.com/package/linkfree-cli/v/2.3.1) version from `2.2.2` to `2.3.1`





<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

