### PR TITLE
fix: resolves issue where <a> tag and <li> are misaligned (#6967)

### DIFF
--- a/pages/docs/quickstart.mdx
+++ b/pages/docs/quickstart.mdx
@@ -158,13 +158,22 @@ An approving review from one of LinkFree's maintainers will show a green check m
 
 Looking for inspiration? You can view the following profiles for an example:
 
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json">
+- <Link
+    href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/eddiejaoude.json"
+    className="text-blue-600 decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid block"
+  >
     Eddie Jaoude
   </Link>
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/amandamartin-dev.json">
+- <Link
+    href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/amandamartin-dev.json"
+    className="text-blue-600 decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid block"
+  >
     Amanda Martin
   </Link>
-- <Link href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json">
+- <Link
+    href="https://github.com/EddieHubCommunity/LinkFree/blob/main/data/Pradumnasaraf.json"
+    className="text-blue-600 decoration-dotted dark:text-blue-500 hover:underline hover:decoration-solid block"
+  >
     Pradumna Saraf
   </Link>
 


### PR DESCRIPTION
## Fixes Issue
Where \<a> tag and \<li> are misaligned in certain browsers (See screenshots)

Closes #6967

## Check List (Check all the applicable boxes) 

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Broken
![Firefox - Broken](https://github.com/EddieHubCommunity/LinkFree/assets/18102814/d1133ae8-0bb5-421c-9258-7447a9f56af1)

Fixed
![Firefox - Fixed](https://github.com/EddieHubCommunity/LinkFree/assets/18102814/2c6746c2-ed7b-46e2-a711-d9f962fec288)


## Note to reviewers

Pre HTML5 \<a> tags could not contain \<p> tags. In HTML5 it is acceptable, however some browsers are flakey about the implementation. Setting the <a> tag's display property to block resolves this.

How do we feel about this solution? Not a big fan of duplicating so many classes, but adding classes to <Link> overrides the default classes and we still want the default classes so this seems the best solution to keep them.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7337"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

