### PR TITLE
fix: vercel single deploy

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -7,8 +7,12 @@ on:
   release:
     types: [published]
   push:
+    # this will deploy data files only when no release is created
     branches:
-      - main # this will deploy data files
+      - main
+    paths:
+      - "data/**"
+
 jobs:
   deploy:
     if: github.repository == 'EddieHubCommunity/LinkFree'


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Vercel GH Action deploys when merged to `main` and also when the release is created (so 2 deploys that are the same)

- we want to deploy on release
- but we also want to deploy when data files are merged to `main` because no release us created
- this will only deploy on `main` for data files

<img width="829" alt="Screenshot 2023-06-04 at 07 41 16" src="https://github.com/EddieHubCommunity/LinkFree/assets/624760/5aa0dcaf-0a2d-437c-bb03-e83a730a11d1">

From GitHub docs https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs


<img width="802" alt="Screenshot 2023-06-04 at 07 43 58" src="https://github.com/EddieHubCommunity/LinkFree/assets/624760/a76abcc5-604f-425d-9a97-6e60ef296dc2">

