### PR TITLE
Fix home page screenshots

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -346,13 +346,12 @@ export default function Home({ total, today }) {
                     "flex-auto lg:row-start-1 lg:col-span-7 xl:col-span-8"
                   )}
                 >
-                  <div className="aspect-w-5 aspect-h-2 overflow-hidden rounded-lg bg-primary-low">
+                  <div className="aspect-w-5 aspect-h-2 overflow-hidden rounded-lg bg-primary-low relative">
                     <Image
                       src={feature.imageSrc}
                       alt={feature.imageAlt}
-                      className="object-cover object-center"
-                      width={1250}
-                      height={840}
+                      className="object-contain object-center"
+                      fill={true}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Changes proposed
Fix the screenshots on the home page to avoid cropping or stretching

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

