### PR TITLE
fix: increase profile page tabs text size (EddieHubCommunity#7049)

### DIFF
--- a/components/user/UserTabs.js
+++ b/components/user/UserTabs.js
@@ -45,7 +45,7 @@ export default function UserTabs({ tabs, setTabs }) {
                   tab.current
                     ? "border-secondary-high dark:border-secondary-low text-secondary-high dark:text-secondary-low"
                     : "border-transparent text-primary-medium dark:text-primary-low-high dark:hover:text-primary-low  hover:text-primary-high hover:border-primary-medium-low",
-                  "w-1/4 py-4 px-1 text-center border-b-2 font-medium text-sm"
+                  "w-1/4 py-4 px-1 text-center border-b-2 font-medium text-lg"
                 )}
                 aria-current={tab.current ? "page" : undefined}
               >


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue #7049

<!-- Remove this section if not applicable -->

Closes #7049 

## Changes proposed

<!-- List all the proposed changes in your PR -->
* Increased the text size in profile page tabs. Initially it was `text-sm` , but now I have changed it to `text-lg`.
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7473"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

