### PR TITLE
Feature: repo-link-open-to-new-tab

### DIFF
--- a/pages/docs/quickstart.mdx
+++ b/pages/docs/quickstart.mdx
@@ -18,7 +18,7 @@ There are 4 ways you can add your profile, but for this Quickstart we will use t
 To do this, you need a GitHub account. If you do not have one yet, you can create one for free with an email address and password.
 
 1. Log in to your GitHub Account
-2. Visit the <Link href="https://github.com/EddieHubCommunity/LinkFree">LinkFree repo</Link>
+2. Visit the <Link href="https://github.com/EddieHubCommunity/LinkFree" target="_blank">LinkFree repo</Link>
 
 ![LinkFree GitHub repo](https://user-images.githubusercontent.com/82668196/208292176-fb2bedf9-8dd1-4fff-b422-30d54f2fdd48.png)
 


### PR DESCRIPTION
Feature: GitHub repositore link on Quickstart page will now open in the new tab.

## Fixes Issue
fix #7476 
Closes #7476 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7494"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

