### PR TITLE
fix: Changed Profile page group link headings from h3 to h2.

### DIFF
--- a/components/user/UserLinks.js
+++ b/components/user/UserLinks.js
@@ -23,9 +23,9 @@ export default function UserLinks({ BASE_URL, data }) {
                   key={name}
                 >
                   <div className="-ml-2 -mt-2 flex flex-wrap items-baseline">
-                    <h3 className="ml-2 mt-2 text-lg font-medium leading-6 dark:text-primary-low text-primary-high">
+                    <h2 className="ml-2 mt-2 text-lg font-medium leading-6 dark:text-primary-low text-primary-high">
                       {name}
-                    </h3>
+                    </h2>
                     <p className="ml-2 mt-1 truncate text-sm dark:text-primary-low-high text-primary-medium">
                       ({buckets[name].length})
                     </p>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #7041 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
components/user/UserLinks.js
```diff
-<h3 className="ml-2 mt-2 text-lg font-medium leading-6 dark:text-primary-low text-primary-high">{name}</h3>
+<h2 className="ml-2 mt-2 text-lg font-medium leading-6 dark:text-primary-low text-primary-high">{name}</h2>
```
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![first-pr-2](https://github.com/EddieHubCommunity/LinkFree/assets/41922950/a5575864-6024-47cb-beb9-5dbd88e210fa)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
Changed the headings from ``<h3>`` to ``<h2>``


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7527"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

