### PR TITLE
data: remove type key from profiles

### DIFF
--- a/data/piaseckijulian.json
+++ b/data/piaseckijulian.json
@@ -1,6 +1,5 @@
 {
   "name": "Julian Piasecki",
-  "type": "personal",
   "bio": "Experienced Software Developer && Front-End Expert | Building amazing projects",
   "links": [
     {

--- a/data/victorchrollo14.json
+++ b/data/victorchrollo14.json
@@ -1,6 +1,5 @@
 {
   "name": "Victor Immanuel",
-  "type": "personal",
   "bio": "Learning to build Things on the web, Ai is next on the menu. ",
   "links": [
     {


### PR DESCRIPTION
## Changes proposed

Remove `type` property from the remaining profile JSON.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

