### PR TITLE
Fix release action warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,27 +15,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # check out the repository with all releases
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       # Create a temporary, uniquely named branch to push release info to
       - name: create temporary branch
-        uses: peterjgrainger/action-create-branch@v2.3.0
-        id: create-branch
-        with:
-          branch: "release-from-${{ github.sha }}"
-          sha: "${{ github.sha }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git branch "release-from-${{ github.sha }}" "${{ github.sha }}"
 
-      # check out the repository afterwards
-      - uses: actions/checkout@v3
-
-      # fetch branches and switch to the temporary branch
+      # switch to the temporary branch
       - name: switch to new branch
-        run: git fetch --all && git checkout --track origin/release-from-${{ github.sha }}
+        run: git checkout release-from-${{ github.sha }}
 
       # update app config with version
       - name: get-npm-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
+        run: |
+          LF_VERSION=$(cat package.json | jq -r '.version')
+          echo "current-version=$LF_VERSION" >> "$GITHUB_OUTPUT"
       - name: update app config
         run: sed -i 's/0.0.0/${{ steps.package-version.outputs.current-version}}/g' config/app.json
 


### PR DESCRIPTION
## Changes proposed
The current release action produces warnings
![Screen Shot 2023-06-12 at 07 33 44](https://github.com/EddieHubCommunity/LinkFree/assets/35927536/c77e67d4-bdeb-4f7d-9f03-85faf75d7b75)

This PR removes the offending actions & replaces them with command built in to the Ubuntu image.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

