### PR TITLE
[FIX] getting localhost in BASE_URL on statistics and playground page

### DIFF
--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -91,11 +91,11 @@ export async function getServerSideProps(context) {
   data.links.clicks = totalClicks;
 
   return {
-    props: { data, profile, progress },
+    props: { data, profile, progress, BASE_URL: clientEnv.NEXT_PUBLIC_BASE_URL },
   };
 }
 
-export default function Statistics({ data, profile, progress }) {
+export default function Statistics({ data, profile, progress, BASE_URL }) {
   const dateTimeStyle = {
     dateStyle: "short",
   };
@@ -151,7 +151,7 @@ export default function Statistics({ data, profile, progress }) {
 
         <h1 className="text-4xl mb-4 font-bold">
           Your Statistics for {profile.name} (
-          <Link href={`${clientEnv.NEXT_PUBLIC_BASE_URL}/${profile.username}`}>
+          <Link href={`${BASE_URL}/${profile.username}`}>
             {profile.username}
           </Link>
           )

--- a/pages/playground.js
+++ b/pages/playground.js
@@ -8,8 +8,14 @@ import UserPage from "@components/user/UserPage";
 import Notification from "@components/Notification";
 import { clientEnv } from "@config/schemas/clientSchema";
 
-export default function Playground() {
-  const BASE_URL = clientEnv.NEXT_PUBLIC_BASE_URL;
+export async function getServerSideProps(){
+  return {
+    props: { BASE_URL: clientEnv.NEXT_PUBLIC_BASE_URL },
+  };
+}
+
+export default function Playground({BASE_URL}) {
+
   const defaultJson = `{
     "name": "Your Name",
     "bio": "Write a short bio about yourself",


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

fixes #7507
 
When clicking on username(hyperlink) on statistics page, it points you to a localhost url. 

<img width="1440" alt="image" src="https://github.com/EddieHubCommunity/LinkFree/assets/54144759/5b20eb8a-5918-4650-bf3e-75da3ddc7707">

<br>

**_To reproduce issue, see the ISSUE page for this PR._**


Same happens with links on Playground page.

<img width="1440" alt="image" src="https://github.com/EddieHubCommunity/LinkFree/assets/54144759/8ef0b539-effd-43c8-98ea-e7b5656e75df">

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

- Getting `BASE_URL` as props
- For reference see `[username].js`

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7640"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

