### PR TITLE
[fix] add directions on link grouping

### DIFF
--- a/pages/docs/how-to-guides/links.mdx
+++ b/pages/docs/how-to-guides/links.mdx
@@ -33,7 +33,7 @@ This is an example of a single link object:
 | icon  | string | true     | The icon you would like displayed. We support the following icon sets: **Fa** and **Si** from React Icons.                                                                                     |
 | group | string | false    | Optional property to group links together, any without a group will be added to the end in a new group called "Others". If no groups are used then no groups are displayed including "Others". |
 
-To add more links add another object inside the links collection. For example:
+To add more links, add another object inside the links collection. For example:
 
 <ClipboardCopy>
 ```js
@@ -56,8 +56,50 @@ To add more links add another object inside the links collection. For example:
 
 _Clicks on these social shortcuts that match any of your links will also increment their respective counters_
 
-### What Links with grouping looks like
+### Grouping your Links 
+To place your social links into categories, you place names like `secondary` or `primary` in the `group` string. Here's an example:
 
+<ClipboardCopy>
+```js
+"links": [
+ {
+      "group": "Business",
+      "name": "Business: DevRel Services",
+      "url": "http://eddiejaoude.io",
+      "icon": "FaLink"
+    },
+    {
+      "group": "Socials Primary",
+      "name": "Twitter: Follow me",
+      "url": "https://twitter.com/eddiejaoude",
+      "icon": "FaTwitter",
+      "color": "#00ACEE"
+    },
+    {
+      "group": "Socials Primary",
+      "name": "YouTube: Learn more about Open Source",
+      "url": "https://youtube.com/eddiejaoude",
+      "icon": "FaYoutube",
+      "color": "#FF0000"
+    },
+    {
+      "group": "Socials Primary",
+      "name": "GitHub: Collaborate on Open Source",
+      "url": "https://github.com/eddiejaoude",
+      "icon": "FaGithub"
+    },
+    {
+      "group": "Socials Primary",
+      "name": "LinkedIn: Let's connect",
+      "url": "https://linkedin.com/in/eddiejaoude",
+      "icon": "FaLinkedin"
+    },
+
+]
+   
+  ```
+</ClipboardCopy>
+Here's how it looks on our website: 
 ![LinkFree profile with grouped links](https://user-images.githubusercontent.com/624760/214538171-099cac71-d2f7-49a8-b3bb-2747506a1bac.png)
 
 export default ({ children }) => (


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #7682 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->
I added directions on how users can categorize their social links in the Links section of their Linkfree profile. 

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

![changes to code](https://github.com/EddieHubCommunity/LinkFree/assets/105683440/74e52e38-2a94-42ba-942c-1231f3835b5f)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
I am open to suggestions on how to make the directions clearer. 
<!-- Add notes to reviewers if applicable -->
