### PR TITLE
docs: add title in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,6 @@
 name: 🐛 Bug
 description: Report an issue to help improve the project.
+title: "[BUG] <description>"
 labels: ["🛠 goal: fix","🚦 status: awaiting triage"]
 body:
   - type: textarea


### PR DESCRIPTION
## Changes proposed

Add a title in the bug issue template

### `[BUG] <description>`



<img width="1323" alt="Screenshot 2023-06-28 at 1 55 04 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/51878265/273dc3f6-86df-4ca0-a3d2-f29a4121cb4d">



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7821"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

