### PR TITLE
Corrected the text color of title in dark mode

### DIFF
--- a/pages/account/no-profile.js
+++ b/pages/account/no-profile.js
@@ -35,7 +35,7 @@ export default function NoProfile({ BASE_URL }) {
         <div className="bg-white">
           <div className="py-24 px-6 sm:px-6 sm:py-32 lg:px-8">
             <div className="mx-auto max-w-2xl text-center">
-              <h2 className="text-4xl font-bold tracking-tight text-primary-high">
+              <h2 className="text-4xl dark-text font-bold tracking-tight text-primary-high">
                 Your LinkFree Profile does not exist yet
               </h2>
               <p className="mx-auto mt-6 max-w-xl text-lg leading-8 text-primary-medium">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,6 +34,9 @@ code.language-unknown::after {
   h6 {
     @apply dark:text-white;
   }
+  .dark-text{
+    @apply dark:text-primary-high;
+  }
   th {
     @apply dark:text-white;
   }


### PR DESCRIPTION



## Changes proposed
In no-profile.js,when in dark mode the color of the (your LinkFree Profile does not exits) change to white which is not visible in white background.So i changed its color to permanent primary-high
1.I have maked a class dark-text in global.css
2. i have added class dark-text in no-profile.js int h2 tag

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7859"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

