### PR TITLE
ci: Add vercel preview PR workflow

### DIFF
--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -28,6 +28,7 @@ jobs:
           ls -l .vercel/output/functions
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > domain.txt
           vercel alias --scope ${{ secrets.VERCEL_TEAM_ID }} --token ${{ secrets.VERCEL_TOKEN }}
+          echo "Deployed to $(cat domain.txt)"
   load-data:
     runs-on: ubuntu-latest
     needs: deploy

--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - "**.js"
+    branches-ignore:    
+      - revert-logger
 
 jobs:
   deploy:

--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -6,10 +6,10 @@ env:
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "**.js"
     branches-ignore:    
       - revert-logger
+    paths:
+      - "**.js"
 
 jobs:
   deploy:

--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -1,0 +1,35 @@
+name: Deploy PR to Preview
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**.js"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: pull Vercel environment information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: build project artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: deploy preview + assign beta domain
+        run: |
+          du --inodes -d 5 .vercel/output
+          ls -l .vercel/output/functions
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > domain.txt
+          vercel alias --scope ${{ secrets.VERCEL_TEAM_ID }} --token ${{ secrets.VERCEL_TOKEN }}
+  load-data:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: load json files
+        if: steps.changes.outputs.data == 'true'
+        run: curl -f https://linkfree-preview.vercel.app/api/system/reload?secret=${{ secrets.LINKFREE_API_SECRET_PREVIEW }}

--- a/.github/workflows/vercel-pr-preview.yml
+++ b/.github/workflows/vercel-pr-preview.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy-preview.outputs.url }}
     steps:
       - uses: actions/checkout@v3
       - name: install Vercel CLI
@@ -22,17 +24,18 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - name: build project artifacts
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - name: deploy preview + assign beta domain
+      - name: deploy preview
+        id: deploy-preview
         run: |
           du --inodes -d 5 .vercel/output
           ls -l .vercel/output/functions
-          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > domain.txt
-          vercel alias --scope ${{ secrets.VERCEL_TEAM_ID }} --token ${{ secrets.VERCEL_TOKEN }}
-          echo "Deployed to $(cat domain.txt)"
+          preview_url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
+          echo "url=$preview_url" >> $GITHUB_OUTPUT
+          echo "deployed to $preview_url"
+
   load-data:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
       - name: load json files
-        if: steps.changes.outputs.data == 'true'
-        run: curl -f https://linkfree-preview.vercel.app/api/system/reload?secret=${{ secrets.LINKFREE_API_SECRET_PREVIEW }}
+        run: curl -f ${{ needs.deploy.outputs.url }}/api/system/reload?secret=${{ secrets.LINKFREE_API_SECRET_PREVIEW }}


### PR DESCRIPTION
## Changes proposed

- Create a Vercel Preview env with every PR that has a change in the JS file.

## Note to reviewers

The reason why I added branches-ignore is that if any preview branch is deployed to a custom domain, it will deploy twice - once with the custom domain and once with this action.

```yaml
    branches-ignore:    
      - revert-logger
```

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7912"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

