### PR TITLE
Remove 0 when there are no links

### DIFF
--- a/components/user/UserLinks.js
+++ b/components/user/UserLinks.js
@@ -18,7 +18,7 @@ export default function UserLinks({
   return (
     <>
       {!links?.length && <Alert type="info" message="No links found" />}
-      {links?.length && (
+      {links?.length > 0 && (
         <>
           {Object.keys(buckets).map((name) => (
             <div key={name} className="flex flex-col items-center w-full">


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Removed the "0" which is displayed when there are no links by modifying the condition.

fixes #7968

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
![Screenshot 2023-07-05 at 12 37 52 PM](https://github.com/EddieHubCommunity/LinkFree/assets/26730019/cd9ff1d7-cba1-4d43-bef3-193007f1d9c5)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
Modified only the condition to check if the links have a length greater than 0.


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/7993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

