### PR TITLE
[fix]: comma misbehave in profile form section

### DIFF
--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -76,15 +76,19 @@ function UserProfile({ BASE_URL, data }) {
       {!qrShow && (
         <div className="flex flex-wrap justify-center">
           {data.tags?.length > 0 &&
-            data.tags.map((tag) => (
-              <Tag
-                name={tag}
-                key={tag.toLowerCase()}
-                onClick={() =>
-                  router.push(`/search?keyword=${tag.toLowerCase()}`)
-                }
-              />
-            ))}
+            data.tags.map((tag, index) => {
+              const trimmed_tag = tag.trim();
+              if (!trimmed_tag) return null;
+              return (
+                <Tag
+                  name={trimmed_tag}
+                  key={index}
+                  onClick={() =>
+                    router.push(`/search?keyword=${trimmed_tag.toLowerCase()}`)
+                  }
+                />
+              );
+            })}
         </div>
       )}
 

--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -78,7 +78,9 @@ function UserProfile({ BASE_URL, data }) {
           {data.tags?.length > 0 &&
             data.tags.map((tag, index) => {
               const trimmedTag = tag.trim();
-              if (!trimmedTag) return null;
+              if (!trimmedTag) {
+                return null;
+              }
               return (
                 <Tag
                   name={trimmedTag}

--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -77,14 +77,14 @@ function UserProfile({ BASE_URL, data }) {
         <div className="flex flex-wrap justify-center">
           {data.tags?.length > 0 &&
             data.tags.map((tag, index) => {
-              const trimmed_tag = tag.trim();
-              if (!trimmed_tag) return null;
+              const trimmedTag = tag.trim();
+              if (!trimmedTag) return null;
               return (
                 <Tag
-                  name={trimmed_tag}
+                  name={trimmedTag}
                   key={index}
                   onClick={() =>
-                    router.push(`/search?keyword=${trimmed_tag.toLowerCase()}`)
+                    router.push(`/search?keyword=${trimmedTag.toLowerCase()}`)
                   }
                 />
               );

--- a/pages/account/manage/profile.js
+++ b/pages/account/manage/profile.js
@@ -93,6 +93,7 @@ export default function Profile({ BASE_URL, profile, fileExists }) {
         ).join(", ")}`,
       });
     }
+    setTags(update.tags);
 
     return setShowNotification({
       show: true,

--- a/pages/api/account/manage/profile.js
+++ b/pages/api/account/manage/profile.js
@@ -57,7 +57,9 @@ export async function updateProfileApi(username, data) {
     layout: data.layout,
     name: data.name,
     bio: data.bio,
-    tags: data.tags.filter((tag) => tag !== ""),
+    tags: data.tags
+      .filter((tag) => Boolean(tag.trim()))
+      .map((tag) => tag.trim()),
   };
 
   try {


### PR DESCRIPTION


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
Closes #8040 

## Changes proposed
- Empty blocks in the tag list won't appear anymore.
- Updating the tags with the response of the profile-update api.
- Updated the key prop's value to the ```index```, if same-named tags are entered multiple times and also for removing them when user removes them from the tag-input field section. Rendered ```Tag``` Components will not unmount if new tags are added.

- Backend API Changes -> Added filter for removing all of the falsy value and string values which contains only whitespaces to prevent whitespaced link generation for the tags when user clicks on them.

Example
if input is ```" javascript,          nextjs        ,,,,,solidjs, vuejs,"```, then they will be result into the ```"javascript, nextjs,solidjs,vuejs"``` while saving in db.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

This is the screenshot of the tags before saving them.
![before_save_tags](https://github.com/EddieHubCommunity/LinkFree/assets/62009244/79ccc10d-3b61-4387-9122-7a9cf1461a02)


This is the screenshot after saving the profile changes.
![after_save_tags](https://github.com/EddieHubCommunity/LinkFree/assets/62009244/e78906ad-84bd-46d8-969b-056dcadf9279)



## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8087"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

