### PR TITLE
fix: broken link in testimonial github action

### DIFF
--- a/.github/workflows/testimonial.yml
+++ b/.github/workflows/testimonial.yml
@@ -80,4 +80,4 @@ jobs:
         uses: YiiGuxing/close-issue@v2.1.0
         with:
           comment: |
-            Testimonial added for @${{ steps.issue-parser.outputs.issueparser_name }}. Thank you for your contribution! @${{ steps.issue-parser.outputs.issueparser_name }} if you wish to add it your LinkFree profile please follow the instructions in the docs https://linkfree.eddiehub.io/docs/how-to-guides/testimonials
+            Testimonial added for @${{ steps.issue-parser.outputs.issueparser_name }}. Thank you for your contribution! @${{ steps.issue-parser.outputs.issueparser_name }} if you wish to add it your LinkFree profile please follow the instructions in the docs https://linkfree.io/docs/how-to-guides/testimonials-json

--- a/.github/workflows/testimonial.yml
+++ b/.github/workflows/testimonial.yml
@@ -80,4 +80,4 @@ jobs:
         uses: YiiGuxing/close-issue@v2.1.0
         with:
           comment: |
-            Testimonial added for @${{ steps.issue-parser.outputs.issueparser_name }}. Thank you for your contribution! @${{ steps.issue-parser.outputs.issueparser_name }} if you wish to add it your LinkFree profile please follow the instructions in the docs https://linkfree.io/docs/how-to-guides/testimonials-json
+            Testimonial added for @${{ steps.issue-parser.outputs.issueparser_name }}. Thank you for your contribution! @${{ steps.issue-parser.outputs.issueparser_name }} if you wish to add it your LinkFree profile please follow the instructions in the docs for json https://linkfree.io/docs/how-to-guides/testimonials-json or for forms https://linkfree.io/docs/how-to-guides/testimonials-forms


### PR DESCRIPTION
## Fixes Issue

Closes #8074 

**Fix of broken link in testimonial github action.**

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8100"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

