### PR TITLE
fix: profile card hover color

### DIFF
--- a/components/user/UserCard.js
+++ b/components/user/UserCard.js
@@ -20,7 +20,7 @@ export default function UserCard({ profile }) {
         />
       </div>
       <div>
-        <h3 className="text-xl justify-center text-center mb-2 text-tertiary-medium font-bold ">
+        <h3 className="text-xl justify-center text-center mb-2 text-tertiary-medium font-bold">
           {profile.name}
         </h3>
         {/* Links inside a link is not allowed, remove them from bio in card */}

--- a/components/user/UserCard.js
+++ b/components/user/UserCard.js
@@ -7,7 +7,7 @@ export default function UserCard({ profile }) {
   return (
     <Link
       href={`/${profile.username}`}
-      className="flex flex-col items-center dark:border-white/10 border-2 w-[14rem] h-[17rem] overflow-hidden rounded-lg shadow-lg transition duration-350 p-4 gap-3 hover:scale-105 duration-500 ease-in-out hover:border-tertiary-medium"
+      className="flex flex-col items-center border-2 w-[14rem] h-[17rem] overflow-hidden rounded-lg shadow-lg transition duration-350 p-4 gap-3 hover:scale-105 duration-500 ease-in-out hover:border-tertiary-medium"
     >
       <div className="flex justify-center relative">
         <FallbackImage
@@ -20,7 +20,7 @@ export default function UserCard({ profile }) {
         />
       </div>
       <div>
-        <h3 className="text-xl justify-center text-center mb-2 text-tertiary-medium font-bold">
+        <h3 className="text-xl justify-center text-center mb-2 text-tertiary-medium font-bold ">
           {profile.name}
         </h3>
         {/* Links inside a link is not allowed, remove them from bio in card */}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 

Closes #8176

## Changes proposed

Fixed the issue where the profile card did not display an orange border when hovered in dark mode.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots


https://github.com/EddieHubCommunity/LinkFree/assets/96465597/56d02566-7191-4531-a286-b1af6d0ab772



This is my first contribution to this project, and I'm excited to be a part of the community. I kindly request your feedback on my changes. If there are any areas for improvement or suggestions, I'm eager to learn and make the necessary updates. Thank you for your time and guidance!




<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

