### PR TITLE
Fixes typo in signup success message for premium updates

### DIFF
--- a/pages/premium.js
+++ b/pages/premium.js
@@ -51,7 +51,7 @@ export default function Premium() {
         {success && (
           <Alert
             type="success"
-            message="Thank you for subscribing. We will notified you when paid features go live"
+            message="Thank you for subscribing. We will notify you when paid features go live"
           />
         )}
 


### PR DESCRIPTION
## Fixes Issue

When signing to news regarding LinkFree's premium tier, the success banner after signup featured a small typo: `notified` instead of `notify`.

## Changes proposed

I fixed the typo :)

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots
I failed to take a screenshot in time :/

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8201"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

