### PR TITLE
SideBar text color changed to black on hover, margin top added to documentation grid card.

### DIFF
--- a/components/navbar/SideNav.js
+++ b/components/navbar/SideNav.js
@@ -15,7 +15,7 @@ export default function SideNav({ navigation }) {
               href={item.href}
               className={classNames(
                 item.current ? "bg-primary-low" : "hover:bg-primary-low",
-                "group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium"
+                "group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium dark:hover:text-primary-high"
               )}
             >
               {/* <item.icon
@@ -31,7 +31,7 @@ export default function SideNav({ navigation }) {
                   <Disclosure.Button
                     className={classNames(
                       item.current ? "bg-primary-low" : "hover:bg-primary-low",
-                      "flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium"
+                      "flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-primary-high dark:text-primary-low-medium dark:hover:text-primary-high"
                     )}
                   >
                     {/* <item.icon
@@ -43,7 +43,7 @@ export default function SideNav({ navigation }) {
                       className={classNames(
                         open
                           ? "rotate-90 text-primary-low-medium"
-                          : "text-primary-low-medium",
+                          : "text-primary-low-medium dark:hover:text-primary-high",
                         "ml-auto h-5 w-5 shrink-0"
                       )}
                       aria-hidden="true"
@@ -60,7 +60,7 @@ export default function SideNav({ navigation }) {
                             subItem.current
                               ? "bg-primary-low"
                               : "hover:bg-primary-low",
-                            "block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-primary-high dark:text-primary-low-medium"
+                            "block rounded-md py-2 pr-2 pl-9 text-sm leading-6 text-primary-high dark:text-primary-low-medium dark:hover:text-primary-high"
                           )}
                         >
                           {subItem.name}

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -112,7 +112,7 @@ export default function DocsIndex() {
                 className="bg-white dark:bg-primary-high px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pb-28"
                 key={section.title}
               >
-                <div className="relative mx-auto max-w-lg divide-y-2 divide-primary-low dark:divide-primary-low-high lg:max-w-7xl">
+                <div className="relative mx-auto max-w-lg divide-y-2 divide-gray-200  dark:divide-primary-low-high lg:max-w-7xl">
                   <div>
                     <h2
                       className="text-3xl font-bold tracking-tight text-primary-high dark:text-primary-low sm:text-4xl"
@@ -124,12 +124,12 @@ export default function DocsIndex() {
                       {section.description}
                     </p>
                   </div>
-                  <div className="mt-12 grid gap-16 lg:grid-cols-3 lg:gap-x-5 lg:gap-y-12">
+                  <div className="mt-12 grid gap-16 lg:grid-cols-3 lg:gap-x-5 lg:gap-y-8">
                     {section.pages.map((page) => (
                       <Link
                         href={page.path}
                         key={page.name}
-                        className="border border-transparent hover:border hover:border-orange-600 transition-all duration-250 ease-linear rounded px-6 py-2 block"
+                        className="border border-transparent hover:border hover:border-orange-600 transition-all duration-250 ease-linear rounded mt-4 px-6 py-2 block"
                       >
                         <div className="py-2">
                           {/* <span


### PR DESCRIPTION


<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
Closes #8165 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
Enhancing the appearance of some UI parts.
Firstly, when hovering over the sidebar, the text colour should be changed to black. This will provide a visually pleasing effect and improve readability. 
second, adding some margin to the top of the grid card will further enhance its appearance
Third, The divider in the documentation grid was not clearly visible, so a darker color was added to enhance visibility.
<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [] The title of my pull request is a short description of the requested changes.

## Screenshots
The issue description already includes a before and after comparison, but I have also attached a screenshot showing the UI after the change.
first
<img width="471" alt="Screenshot 2023-07-15 at 6 31 34 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/88904952/c407559b-1c45-4f0a-83ab-9a00c9cc8b04">
second
<img width="356" alt="Screenshot 2023-07-15 at 6 31 41 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/88904952/2a16dcc4-0937-4694-a4c3-9dc1a0b28b6a">

third's
before
<img width="412" alt="Screenshot 2023-07-15 at 6 32 12 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/88904952/328ee0ee-f9f6-4a32-9675-14ef1288f461">
after
<img width="700" alt="Screenshot 2023-07-15 at 6 31 53 PM" src="https://github.com/EddieHubCommunity/LinkFree/assets/88904952/8ddc9c46-22f4-4cff-af31-aee2dc535d97">


<!-- Add all the screenshots which support your changes -->

## Note to reviewers
I have set the margin in the documentation grid based on my own preference. However, if the reviewer believes that the margin should be adjusted to be less or more, please feel free to make the changes according to your own judgment
<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8209"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

