### PR TITLE
Fixed the Background colour issue of the Button in Playground Screen at Light Mode

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -7,7 +7,7 @@ export default function Button({
   ...restProps
 }) {
   let className =
-    "w-full inline-flex items-center flex-1 justify-center rounded-md border border-transparent px-5 py-3 text-base font-medium first-letter:bg-white transition duration-400 ease-in-out";
+    "w-full inline-flex items-center flex-1 justify-center rounded-md border border-transparent px-5 py-3 text-base font-medium first-letter:bg-white transition duration-400 ease-in-out bg-gray-300";
   !disable
     ? (className += primary
         ? " text-white bg-secondary-medium hover:bg-secondary-high"


### PR DESCRIPTION
- The Colour of the Button in Playground screen was not clear enough.
-  I Fixed it By adding a Slight Gray Colour as a Background on the Button.

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8231"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

