### PR TITLE
fix: GHCR workflow command

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -48,7 +48,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       - name: Setup Env
-        run: echo "LINKFREE_MONGO_CONNECTION_STRING=${{ secrets.LINKFREE_MONGO_CONNECTION_STRING }}" > /tmp/.env
+        run: echo "LINKFREE_MONGO_CONNECTION_STRING=${{ secrets.LINKFREE_MONGO_CONNECTION_STRING }}" >> /tmp/.env
       - name: push to Github Container Registry
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
## Changes proposed

`>` to `>>`

```bash 
echo "LINKFREE_MONGO_CONNECTION_STRING=${{ secrets.LINKFREE_MONGO_CONNECTION_STRING }}" >> /tmp/.env
```





<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8304"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

