### PR TITLE
Change Error to Warning when users not loaded in development

### DIFF
--- a/pages/api/discover/random.js
+++ b/pages/api/discover/random.js
@@ -42,6 +42,10 @@ export async function getRandomProfileApi() {
 
     return JSON.parse(JSON.stringify(profile ? profile[0] : {}));
   } catch (error) {
+    if (serverEnv.NODE_ENV === "development") {
+      logger.info("Users not loaded. Please visit http://localhost:3000/api/system/reload?secret=development");
+      return {};
+    }
     logger.error(error, "Error fetching user profiles");
     return { error: "Failed to fetch user profiles" };
   }

--- a/pages/api/discover/random.js
+++ b/pages/api/discover/random.js
@@ -43,7 +43,7 @@ export async function getRandomProfileApi() {
     return JSON.parse(JSON.stringify(profile ? profile[0] : {}));
   } catch (error) {
     if (serverEnv.NODE_ENV === "development") {
-      logger.info("Users not loaded. Please visit http://localhost:3000/api/system/reload?secret=development");
+      logger.warn("Users not loaded. Please visit /api/system/reload?secret=development");
       return {};
     }
     logger.error(error, "Error fetching user profiles");


### PR DESCRIPTION
## Changes proposed
Change message when `getRandomProfileApi()` fails in development to be a warning mentioning loading users.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8422"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

