### PR TITLE
fix: search for icons input text not visible

### DIFF
--- a/pages/icons.js
+++ b/pages/icons.js
@@ -56,7 +56,7 @@ export default function Icons() {
         <h1 className="text-4xl mb-4  font-bold">Search For Icons</h1>
         <input
           placeholder="Search Icons (minimum 3 characters)"
-          className="border-2 hover:border-tertiary-medium transition-all duration-250 ease-linear rounded px-6 py-2 mb-4"
+          className="border-2 hover:border-tertiary-medium transition-all duration-250 ease-linear rounded px-6 py-2 mb-4 text-black"
           name="keyword"
           onChange={(e) => searchIcons(e.target.value)}
         />


### PR DESCRIPTION
## Changes proposed

<!-- List all the proposed changes in your PR -->
Made icon search input text black. This is beacuse previously it was not viable when typing.
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8423"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

