### PR TITLE
Fixed #8433 : Add spaces between the missing sections in profile page

### DIFF
--- a/pages/account/statistics.js
+++ b/pages/account/statistics.js
@@ -131,7 +131,7 @@ export default function Statistics({ data, profile, progress, BASE_URL }) {
             {progress.missing.length > 0 && (
               <span className="text-primary-medium-low">
                 (missing sections in your profile are:{" "}
-                {progress.missing.join(",")})
+                {progress.missing.join(", ")})
               </span>
             )}
           </span>


### PR DESCRIPTION
## Fixes Issue : 
fixes #8433

## Changes proposed

- Added changes to statistics, added a space after "," in the join method to give a space after each progress.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots


![Screenshot (263)](https://github.com/EddieHubCommunity/LinkFree/assets/140178357/7a9920f9-9145-4be9-a55d-8c8d445d4cba)



<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8447"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

