### PR TITLE
fix: close button of download qr code modal fixed (#8455)

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -39,7 +39,7 @@ export default function Modal({
                 <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
                   <button
                     type="button"
-                    className="rounded-md bg-white dark:bg-primary-high text-primary-low-medium hover:text-primary-low-medium focus:outline-none focus:ring-2 focus:ring-secondary-medium-low focus:ring-offset-2"
+                    className="rounded-md bg-white dark:bg-primary-high text-primary-low-medium hover:text-primary-low-medium focus:outline-none hover:ring-2 hover:ring-secondary-medium-low hover:ring-offset-2"
                     onClick={() => setShow(false)}
                   >
                     <span className="sr-only">Close</span>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #8455 
<!-- Example: Closes #31 -->

## Changes proposed

- In the download QR code section, the close tab is highlighted already. It should not be highlighted.
- Fix: Changed the already highlighted close button to highlight on hover. Screenshots are attached.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Before changes: Default button
<img width="100" alt="image" src="https://user-images.githubusercontent.com/117305467/257729279-93914e22-53f0-4f33-b9e4-e39193e19cfa.png">

After changes: Default button
<img width="74" alt="image" src="https://github.com/EddieHubCommunity/LinkFree/assets/77712031/27b83151-ff57-4b67-8b0b-64a18db107bf">

After changes: On hover button
<img width="80" alt="image" src="https://github.com/EddieHubCommunity/LinkFree/assets/77712031/d34d6b69-869a-4599-b2cd-d7f80144daa4">


## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8496"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

