### PR TITLE
Fixed #8526 : QR code link width 

### DIFF
--- a/components/ClipboardCopy.js
+++ b/components/ClipboardCopy.js
@@ -27,7 +27,7 @@ const ClipboardCopy = ({ children }) => {
   };
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <div className="bg-primary-medium-low absolute flex items-center space-x-2 top-0 right-0 p-2 m-2 z-10 rounded-md transition hover:bg-primary-high ease-in-out duration-300">
         <button
           type="button"

--- a/components/user/UserProfile.js
+++ b/components/user/UserProfile.js
@@ -135,7 +135,7 @@ function UserProfile({ BASE_URL, data }) {
                   </Link>
                 ))}
               </div>
-              <div className="w-full flex items-center justify-center">
+              <div className=" flex items-center justify-center w-full overflow-hidden">
                 <ClipboardCopy>
                   <p className="dark:text-gray-300 border p-3 rounded-md">
                     {`${BASE_URL}/${data.username}`}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 

fixes #8526 

## Changes proposed
I fixed the issue by setting the width of the ClipboardCopy component to "w-full" , so the child can have "w-full" applied to it successfully , I also checked pages that contain ClipboardCopy component to check if anything changes in there , and I saw them looking well and working perfectly

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/EddieHubCommunity/LinkFree/assets/77692478/ea9212f3-5a70-408f-86f2-03811d573eee)

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8566"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

