### PR TITLE
Fix dark mode display issue for bio label

### DIFF
--- a/components/form/Textarea.js
+++ b/components/form/Textarea.js
@@ -3,7 +3,7 @@ export default function Textarea({ name, value, label, ...restProps }) {
     <div>
       <label
         htmlFor={name}
-        className="block text-sm font-medium leading-6 text-gray-900"
+        className="block text-sm font-medium leading-6 text-gray-900 dark:text-white"
       >
         {label}
       </label>
@@ -12,7 +12,7 @@ export default function Textarea({ name, value, label, ...restProps }) {
           rows={4}
           name={name}
           id={name}
-          className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+          className="block w-full rounded-md border-0 py-1.5 text-gray-900  shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
           defaultValue={value}
           {...restProps}
         />

--- a/components/form/Textarea.js
+++ b/components/form/Textarea.js
@@ -12,7 +12,7 @@ export default function Textarea({ name, value, label, ...restProps }) {
           rows={4}
           name={name}
           id={name}
-          className="block w-full rounded-md border-0 py-1.5 text-gray-900  shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+          className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
           defaultValue={value}
           {...restProps}
         />

--- a/components/form/Textarea.js
+++ b/components/form/Textarea.js
@@ -3,7 +3,7 @@ export default function Textarea({ name, value, label, ...restProps }) {
     <div>
       <label
         htmlFor={name}
-        className="block text-sm font-medium leading-6 text-gray-900 dark:text-primary-low"
+        className="block text-sm font-medium leading-6 text-primary-high dark:text-primary-low"
       >
         {label}
       </label>

--- a/components/form/Textarea.js
+++ b/components/form/Textarea.js
@@ -3,7 +3,7 @@ export default function Textarea({ name, value, label, ...restProps }) {
     <div>
       <label
         htmlFor={name}
-        className="block text-sm font-medium leading-6 text-gray-900 dark:text-white"
+        className="block text-sm font-medium leading-6 text-gray-900 dark:text-primary-low"
       >
         {label}
       </label>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes #8664 

fixes #8664 

closes #8664 

## Changes proposed

<!-- List all the proposed changes in your PR -->

i fixed a bug that, the in `account/manage/profile` page, the **BIO** label is not visible in dark mode, i changed the color of this label to white and fixed the issue. So that, it resolves issue where the bio label was not visible in dark mode.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

no screenshots taken, but check the issue, it won't repeat again

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

This pull request addresses the issue where the bio label was not being displayed correctly in dark mode. I've fixed the styling so that the bio label now shows up properly even in dark mode.

<!-- Add notes to reviewers if applicable -->


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/LinkFree/pull/8669"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

